### PR TITLE
Swift 1.2

### DIFF
--- a/Geocoder Example/AppDelegate.swift
+++ b/Geocoder Example/AppDelegate.swift
@@ -6,7 +6,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var window: UIWindow?
 
-    func application(application: UIApplication!, didFinishLaunchingWithOptions launchOptions: NSDictionary!) -> Bool {
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
         window = UIWindow(frame: UIScreen.mainScreen().bounds)
         window!.rootViewController = ViewController(nibName: nil, bundle: nil)
         window!.makeKeyAndVisible()

--- a/Geocoder Example/ViewController.m
+++ b/Geocoder Example/ViewController.m
@@ -34,7 +34,9 @@ NSString *const MapboxAccessToken = @"pk.eyJ1IjoianVzdGluIiwiYSI6ImFqZFg3Q0UifQ.
     self.mapView.delegate = self;
     [self.view addSubview:self.mapView];
 
-    self.resultsLabel = [[UILabel alloc] initWithFrame:CGRectMake(20, 20, 500, 30)];
+    self.resultsLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 20, self.view.bounds.size.width - 20, 30)];
+    self.resultsLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth
+    self.resultsLabel.adjustsFontSizeToFitWidth = YES
     self.resultsLabel.backgroundColor = [[UIColor whiteColor] colorWithAlphaComponent:0.5];
     self.resultsLabel.userInteractionEnabled = NO;
     [self.view addSubview:self.resultsLabel];

--- a/Geocoder Example/ViewController.swift
+++ b/Geocoder Example/ViewController.swift
@@ -22,11 +22,13 @@ class ViewController: UIViewController, MKMapViewDelegate {
         super.viewDidLoad()
         
         mapView = MKMapView(frame: view.bounds)
-        mapView.autoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight
+        mapView.autoresizingMask = .FlexibleWidth | .FlexibleHeight
         mapView.delegate = self
         view.addSubview(mapView)
         
-        resultsLabel = UILabel(frame: CGRect(x: 20, y: 20, width: 500, height: 30))
+        resultsLabel = UILabel(frame: CGRect(x: 10, y: 20, width: view.bounds.size.width - 20, height: 30))
+        resultsLabel.autoresizingMask = .FlexibleWidth
+        resultsLabel.adjustsFontSizeToFitWidth = true
         resultsLabel.backgroundColor = UIColor.whiteColor().colorWithAlphaComponent(0.5)
         resultsLabel.userInteractionEnabled = false
         view.addSubview(resultsLabel)

--- a/Geocoder Example/ViewController.swift
+++ b/Geocoder Example/ViewController.swift
@@ -10,10 +10,10 @@ class ViewController: UIViewController, MKMapViewDelegate {
     // MARK: -
     // MARK: Variables
 
-    var mapView: MKMapView?
-    var resultsLabel: UILabel?
-//    var geocoder: CLGeocoder?
-    var geocoder: MBGeocoder?
+    var mapView: MKMapView!
+    var resultsLabel: UILabel!
+//    var geocoder: CLGeocoder!
+    var geocoder: MBGeocoder!
     
     // MARK: -
     // MARK: Setup
@@ -22,14 +22,14 @@ class ViewController: UIViewController, MKMapViewDelegate {
         super.viewDidLoad()
         
         mapView = MKMapView(frame: view.bounds)
-        mapView!.autoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight
-        mapView!.delegate = self
-        view.addSubview(mapView!)
+        mapView.autoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight
+        mapView.delegate = self
+        view.addSubview(mapView)
         
         resultsLabel = UILabel(frame: CGRect(x: 20, y: 20, width: 500, height: 30))
-        resultsLabel!.backgroundColor = UIColor.whiteColor().colorWithAlphaComponent(0.5)
-        resultsLabel!.userInteractionEnabled = false
-        view.addSubview(resultsLabel!)
+        resultsLabel.backgroundColor = UIColor.whiteColor().colorWithAlphaComponent(0.5)
+        resultsLabel.userInteractionEnabled = false
+        view.addSubview(resultsLabel)
         
 //        geocoder = CLGeocoder()
         geocoder = MBGeocoder(accessToken: MapboxAccessToken)
@@ -38,20 +38,21 @@ class ViewController: UIViewController, MKMapViewDelegate {
     // MARK: -
     // MARK: MKMapViewDelegate
 
-    func mapView(mapView: MKMapView!, regionWillChangeAnimated animated: Bool) {
-        geocoder?.cancelGeocode()
+    func mapView(mapView: MKMapView, regionWillChangeAnimated animated: Bool) {
+        geocoder.cancelGeocode()
     }
     
-    func mapView(mapView: MKMapView!, regionDidChangeAnimated animated: Bool) {
-        geocoder?.cancelGeocode()
-        geocoder!.reverseGeocodeLocation(CLLocation(latitude: mapView!.centerCoordinate.latitude, longitude: mapView!.centerCoordinate.longitude)) { (results, error) in
+    func mapView(mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
+        geocoder.cancelGeocode()
+        geocoder.reverseGeocodeLocation(CLLocation(latitude: mapView.centerCoordinate.latitude,
+            longitude: mapView.centerCoordinate.longitude)) { [unowned self] (results, error) in
             if (error != nil) {
                 NSLog("%@", error)
             } else if results.count > 0 {
-//                self.resultsLabel!.text = (results[0] as CLPlacemark).name
-                self.resultsLabel!.text = (results[0] as! MBPlacemark).name
+//                self.resultsLabel.text = (results[0] as CLPlacemark).name
+                self.resultsLabel.text = (results[0] as! MBPlacemark).name
             } else {
-                self.resultsLabel!.text = "No results"
+                self.resultsLabel.text = "No results"
             }
         }
     }

--- a/Geocoder Example/ViewController.swift
+++ b/Geocoder Example/ViewController.swift
@@ -49,7 +49,7 @@ class ViewController: UIViewController, MKMapViewDelegate {
                 NSLog("%@", error)
             } else if results.count > 0 {
 //                self.resultsLabel!.text = (results[0] as CLPlacemark).name
-                self.resultsLabel!.text = (results[0] as MBPlacemark).name
+                self.resultsLabel!.text = (results[0] as! MBPlacemark).name
             } else {
                 self.resultsLabel!.text = "No results"
             }

--- a/MBGeocoder/MapboxGeocoder.swift
+++ b/MBGeocoder/MapboxGeocoder.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreLocation
 
-public typealias MBGeocodeCompletionHandler = CLGeocodeCompletionHandler // FIXME ObjC
+public typealias MBGeocodeCompletionHandler = CLGeocodeCompletionHandler
 
 // MARK: - Geocoder
 
@@ -24,7 +24,7 @@ public class MBGeocoder: NSObject,
     
     private let MBGeocoderErrorDomain = "MBGeocoderErrorDomain"
 
-    private enum MBGeocoderErrorCode: Int { // FIXME ObjC
+    private enum MBGeocoderErrorCode: Int {
         case ConnectionError = -1000
         case HTTPError       = -1001
         case ParseError      = -1002

--- a/MBGeocoder/MapboxGeocoder.swift
+++ b/MBGeocoder/MapboxGeocoder.swift
@@ -172,69 +172,69 @@ public class MBPlacemark: NSObject, NSCopying, NSSecureCoding {
         aCoder.encodeObject(featureJSON, forKey: "featureJSON")
     }
 
-    public var location: CLLocation {
+    public var location: CLLocation! {
         let coordinates = (self.featureJSON!["geometry"] as! NSDictionary)["coordinates"] as! NSArray
 
         return CLLocation(latitude: coordinates[1].doubleValue, longitude: coordinates[0].doubleValue)
     }
 
-    public var name: String {
+    public var name: String! {
         return self.featureJSON!["place_name"] as! String
     }
 
-    public var addressDictionary: [NSObject: AnyObject] {
+    public var addressDictionary: [NSObject: AnyObject]! {
         return [:]
     }
 
-    public var ISOcountryCode: String {
+    public var ISOcountryCode: String! {
         return ""
     }
 
-    public var country: String {
+    public var country: String! {
         return ""
     }
 
-    public var postalCode: String {
+    public var postalCode: String! {
         return ""
     }
 
-    public var administrativeArea: String {
+    public var administrativeArea: String! {
         return ""
     }
 
-    public var subAdministrativeArea: String {
+    public var subAdministrativeArea: String! {
         return ""
     }
 
-    public var locality: String {
+    public var locality: String! {
         return ""
     }
 
-    public var subLocality: String {
+    public var subLocality: String! {
         return ""
     }
 
-    public var thoroughfare: String {
+    public var thoroughfare: String! {
         return ""
     }
 
-    public var subThoroughfare: String {
+    public var subThoroughfare: String! {
         return ""
     }
 
-    public var region: CLRegion {
+    public var region: CLRegion! {
         return CLRegion()
     }
 
-    public var inlandWater: String {
+    public var inlandWater: String! {
         return ""
     }
 
-    public var ocean: String {
+    public var ocean: String! {
         return ""
     }
 
-    public var areasOfInterest: [AnyObject] {
+    public var areasOfInterest: [AnyObject]! {
         return []
     }
 

--- a/MBGeocoder/MapboxGeocoder.swift
+++ b/MBGeocoder/MapboxGeocoder.swift
@@ -133,7 +133,7 @@ public class MBPlacemark: NSObject, NSCopying, NSSecureCoding, NSCoding {
         super.init()
     }
 
-    public convenience init!(placemark: MBPlacemark!) {
+    public convenience init(placemark: MBPlacemark) {
         self.init()
         featureJSON = placemark.featureJSON
     }
@@ -143,7 +143,7 @@ public class MBPlacemark: NSObject, NSCopying, NSSecureCoding, NSCoding {
         if let geometry = featureJSON["geometry"] as? NSDictionary {
             if geometry["type"] as? String == "Point" {
                 if geometry["coordinates"] as? NSArray != nil {
-                    if (featureJSON["place_name"] as? String != nil) {
+                    if featureJSON["place_name"] as? String != nil {
                         valid = true
                     }
                 }
@@ -171,69 +171,69 @@ public class MBPlacemark: NSObject, NSCopying, NSSecureCoding, NSCoding {
         aCoder.encodeObject(featureJSON, forKey: "featureJSON")
     }
 
-    public var location: CLLocation! {
+    public var location: CLLocation {
         let coordinates = (self.featureJSON!["geometry"] as! NSDictionary)["coordinates"] as! NSArray
 
-        return CLLocation(latitude:  coordinates[1].doubleValue, longitude: coordinates[0].doubleValue)
+        return CLLocation(latitude: coordinates[1].doubleValue, longitude: coordinates[0].doubleValue)
     }
 
-    public var name: String! {
+    public var name: String {
         return self.featureJSON!["place_name"] as! String
     }
 
-    public var addressDictionary: [NSObject: AnyObject]! {
+    public var addressDictionary: [NSObject: AnyObject] {
         return [:]
     }
 
-    public var ISOcountryCode: String! {
+    public var ISOcountryCode: String {
         return ""
     }
 
-    public var country: String! {
+    public var country: String {
         return ""
     }
 
-    public var postalCode: String! {
+    public var postalCode: String {
         return ""
     }
 
-    public var administrativeArea: String! {
+    public var administrativeArea: String {
         return ""
     }
 
-    public var subAdministrativeArea: String! {
+    public var subAdministrativeArea: String {
         return ""
     }
 
-    public var locality: String! {
+    public var locality: String {
         return ""
     }
 
-    public var subLocality: String! {
+    public var subLocality: String {
         return ""
     }
 
-    public var thoroughfare: String! {
+    public var thoroughfare: String {
         return ""
     }
 
-    public var subThoroughfare: String! {
+    public var subThoroughfare: String {
         return ""
     }
 
-    public var region: CLRegion! {
+    public var region: CLRegion {
         return CLRegion()
     }
 
-    public var inlandWater: String! {
+    public var inlandWater: String {
         return ""
     }
 
-    public var ocean: String! {
+    public var ocean: String {
         return ""
     }
 
-    public var areasOfInterest: [AnyObject]! {
+    public var areasOfInterest: [AnyObject] {
         return []
     }
 

--- a/MBGeocoder/MapboxGeocoder.swift
+++ b/MBGeocoder/MapboxGeocoder.swift
@@ -120,8 +120,9 @@ public class MBGeocoder: NSObject,
 
 // MARK: - Placemark
 
-/** @see CLPlacemark */
-public class MBPlacemark: NSObject, NSCopying, NSSecureCoding, NSCoding {
+// Based on CLPlacemark, which can't be reliably subclassed in Swift.
+
+public class MBPlacemark: NSObject, NSCopying, NSSecureCoding {
 
     private var featureJSON: NSDictionary?
 


### PR DESCRIPTION
 - `MBPlacemark` no longer subclasses `CLPlacemark`.
 - `String` and `NSString` no longer bridge as seamlessly anymore.
 - Optionality checks are more stringent now.

/cc @incanus