### PR TITLE
Keep access token out of this repository

### DIFF
--- a/Geocoder Example.xcodeproj/project.pbxproj
+++ b/Geocoder Example.xcodeproj/project.pbxproj
@@ -286,6 +286,7 @@
 				DD342B4D19A140EE00219F77 /* Frameworks */,
 				DD342B4E19A140EE00219F77 /* Resources */,
 				DDC2471919A1C3B40054B0C0 /* Embed Frameworks */,
+				DA7705901C66AAFD003AB296 /* Insert Mapbox Access Token */,
 			);
 			buildRules = (
 			);
@@ -323,6 +324,7 @@
 				DDC2472719A1C60E0054B0C0 /* Frameworks */,
 				DDC2472819A1C60E0054B0C0 /* Resources */,
 				DDC2475119A1CBE20054B0C0 /* Embed Frameworks */,
+				DA7705911C66AC6E003AB296 /* Insert Mapbox Access Token */,
 			);
 			buildRules = (
 			);
@@ -480,6 +482,34 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Unit Tests/Pods-Unit Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		DA7705901C66AAFD003AB296 /* Insert Mapbox Access Token */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Insert Mapbox Access Token";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "token_file=~/.mapbox\ntoken=\"$(cat $token_file)\"\nif [ \"$token\" ]; then\nplutil -replace MGLMapboxAccessToken -string $token \"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\nelse\necho 'error: Missing Mapbox access token'\nopen 'https://www.mapbox.com/studio/account/tokens/'\necho \"error: Get an access token from <https://www.mapbox.com/studio/account/tokens/>, then create a new file at $token_file that contains the access token.\"\nexit 1\nfi";
+		};
+		DA7705911C66AC6E003AB296 /* Insert Mapbox Access Token */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Insert Mapbox Access Token";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "token_file=~/.mapbox\ntoken=\"$(cat $token_file)\"\nif [ \"$token\" ]; then\nplutil -replace MGLMapboxAccessToken -string $token \"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\nelse\necho 'error: Missing Mapbox access token'\nopen 'https://www.mapbox.com/studio/account/tokens/'\necho \"error: Get an access token from <https://www.mapbox.com/studio/account/tokens/>, then create a new file at $token_file that contains the access token.\"\nexit 1\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Geocoder Example/AppDelegate.h
+++ b/Geocoder Example/AppDelegate.h
@@ -1,5 +1,7 @@
 @import UIKit;
 
+extern NSString *MapboxAccessToken;
+
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;

--- a/Geocoder Example/AppDelegate.m
+++ b/Geocoder Example/AppDelegate.m
@@ -1,7 +1,17 @@
 #import "AppDelegate.h"
 #import "ViewController.h"
 
+// A Mapbox access token is required to use the Geocoding API.
+// https://www.mapbox.com/help/create-api-access-token/
+NSString *MapboxAccessToken = nil;
+
 @implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    MapboxAccessToken = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"MGLMapboxAccessToken"];
+    
+    return YES;
+}
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];

--- a/Geocoder Example/AppDelegate.swift
+++ b/Geocoder Example/AppDelegate.swift
@@ -1,7 +1,10 @@
 import UIKit
 
-@UIApplicationMain
+// A Mapbox access token is required to use the Geocoding API.
+// https://www.mapbox.com/help/create-api-access-token/
+let MapboxAccessToken = NSBundle.mainBundle().objectForInfoDictionaryKey("MGLMapboxAccessToken") as? String ?? ""
 
+@UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var window: UIWindow?

--- a/Geocoder Example/ViewController.m
+++ b/Geocoder Example/ViewController.m
@@ -4,9 +4,7 @@
 
 #import "ViewController.h"
 
-// A Mapbox access token is required to use the Geocoding API.
-// https://www.mapbox.com/help/create-api-access-token/
-NSString *const MapboxAccessToken = @"<# your Mapbox access token #>";
+#import "AppDelegate.h"
 
 @interface ViewController () <MKMapViewDelegate>
 

--- a/Geocoder Example/ViewController.swift
+++ b/Geocoder Example/ViewController.swift
@@ -3,10 +3,6 @@ import MapKit
 import CoreLocation
 import MapboxGeocoder
 
-// A Mapbox access token is required to use the Geocoding API.
-// https://www.mapbox.com/help/create-api-access-token/
-let MapboxAccessToken = "<# your Mapbox access token #>"
-
 class ViewController: UIViewController, MKMapViewDelegate {
     
     // MARK: -

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ MapboxGeocoder.swift
 
 Import `MapboxGeocoder.framework` into your project, then use `MBGeocoder` as a drop-in replacement for Apple's `CLGeocoder`.
 
-Includes example applications written in both Swift and Objective-C showing use of the framework (as well as a comparison of writing apps in either language). 
+Includes example applications written in both Swift and Objective-C showing use of the framework (as well as a comparison of writing apps in either language). Before you can build either example project, you’ll need to save a plain text file named `.mapbox` to your home directory containing your [Mapbox access token](https://www.mapbox.com/studio/account/tokens/).
 
-Head straight to [`MapboxGeocoder.swift`](https://github.com/incanus/GeocoderExample/blob/master/MBGeocoder/MapboxGeocoder.swift) if you want to see the guts of the library. 
+Head straight to [`MapboxGeocoder.swift`](https://github.com/incanus/GeocoderExample/blob/master/MBGeocoder/MapboxGeocoder.swift) if you want to see the guts of the library.
 
 ### Tests
 


### PR DESCRIPTION
Read the access token [from an unversioned file at build time](https://www.mapbox.com/help/ios-private-access-token/). This way I’m much less likely to accidentally check in an access token of mine while developing the framework.

/cc @friedbunny
