### PR TITLE
Convert Podfile to individual targets for CocoaPods 1.0.0

### DIFF
--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		12F407DDE8B7F17A70A9EC6F /* Pods_MapboxGeocoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 76927FB33641E3D7F2ED1B2E /* Pods_MapboxGeocoder.framework */; };
 		8DF260A67CA4C55F8FA7CAA0 /* Pods_MapboxGeocoderTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9CD6EA86BBE0D7DE16654CB4 /* Pods_MapboxGeocoderTests.framework */; };
-		9FB47CA319B32DD7142B5830 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6953F60F050AE274E006CB85 /* Pods.framework */; };
 		DA210BAB1CB4BE73008088FD /* ForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA210BAA1CB4BE73008088FD /* ForwardGeocodingTests.swift */; };
 		DA210BAD1CB4BFF7008088FD /* forward_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = DA210BAC1CB4BFF7008088FD /* forward_valid.json */; };
 		DA210BAF1CB4C5A7008088FD /* forward_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = DA210BAE1CB4C5A7008088FD /* forward_invalid.json */; };
@@ -92,14 +92,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		045C1E17B01F46F0A4474B78 /* Pods-Unit Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Unit Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Unit Tests/Pods-Unit Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		17AE996AFE6CDB18135D3ABA /* Pods-MapboxGeocoderTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxGeocoderTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxGeocoderTests/Pods-MapboxGeocoderTests.debug.xcconfig"; sourceTree = "<group>"; };
 		53A4FB553E5C07CD9CE68E00 /* Pods-MapboxGeocoderTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxGeocoderTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxGeocoderTests/Pods-MapboxGeocoderTests.release.xcconfig"; sourceTree = "<group>"; };
-		6953F60F050AE274E006CB85 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B55078E561746475518C5B0 /* Pods-MapboxGeocoder.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxGeocoder.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxGeocoder/Pods-MapboxGeocoder.release.xcconfig"; sourceTree = "<group>"; };
+		76927FB33641E3D7F2ED1B2E /* Pods_MapboxGeocoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxGeocoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9CD6EA86BBE0D7DE16654CB4 /* Pods_MapboxGeocoderTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxGeocoderTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		A7FEE3C3AC9D553F9763CB06 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
-		CC09570CD1A6D11014400590 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
-		D9281D748078BEB61AACF246 /* Pods_Unit_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Unit_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B4B7718C3CC6CB35C1916D3E /* Pods-MapboxGeocoder.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxGeocoder.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxGeocoder/Pods-MapboxGeocoder.debug.xcconfig"; sourceTree = "<group>"; };
 		DA210BAA1CB4BE73008088FD /* ForwardGeocodingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForwardGeocodingTests.swift; sourceTree = "<group>"; };
 		DA210BAC1CB4BFF7008088FD /* forward_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = forward_valid.json; sourceTree = "<group>"; };
 		DA210BAE1CB4C5A7008088FD /* forward_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = forward_invalid.json; sourceTree = "<group>"; };
@@ -129,7 +127,6 @@
 		DDF1E84E1BD6F7BA00C40C78 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DDF1E85A1BD70E4C00C40C78 /* reverse_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = reverse_invalid.json; sourceTree = "<group>"; };
 		DDF1E85B1BD70E4C00C40C78 /* reverse_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = reverse_valid.json; sourceTree = "<group>"; };
-		FEF1C362A84DCF91463C3181 /* Pods-Unit Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Unit Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Unit Tests/Pods-Unit Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,7 +135,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				DDC2471819A1C3B40054B0C0 /* MapboxGeocoder.framework in Frameworks */,
-				9FB47CA319B32DD7142B5830 /* Pods.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -147,6 +143,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DA2E03F91CB0FFF700D1269A /* RequestKit.framework in Frameworks */,
+				12F407DDE8B7F17A70A9EC6F /* Pods_MapboxGeocoder.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,12 +169,10 @@
 		35099EC49328A9D78984B007 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				045C1E17B01F46F0A4474B78 /* Pods-Unit Tests.debug.xcconfig */,
-				FEF1C362A84DCF91463C3181 /* Pods-Unit Tests.release.xcconfig */,
-				A7FEE3C3AC9D553F9763CB06 /* Pods.debug.xcconfig */,
-				CC09570CD1A6D11014400590 /* Pods.release.xcconfig */,
 				17AE996AFE6CDB18135D3ABA /* Pods-MapboxGeocoderTests.debug.xcconfig */,
 				53A4FB553E5C07CD9CE68E00 /* Pods-MapboxGeocoderTests.release.xcconfig */,
+				B4B7718C3CC6CB35C1916D3E /* Pods-MapboxGeocoder.debug.xcconfig */,
+				6B55078E561746475518C5B0 /* Pods-MapboxGeocoder.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -186,9 +181,8 @@
 			isa = PBXGroup;
 			children = (
 				DA2E03F81CB0FFF700D1269A /* RequestKit.framework */,
-				D9281D748078BEB61AACF246 /* Pods_Unit_Tests.framework */,
-				6953F60F050AE274E006CB85 /* Pods.framework */,
 				9CD6EA86BBE0D7DE16654CB4 /* Pods_MapboxGeocoderTests.framework */,
+				76927FB33641E3D7F2ED1B2E /* Pods_MapboxGeocoder.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -328,13 +322,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DD342B6C19A140EE00219F77 /* Build configuration list for PBXNativeTarget "Example (Swift)" */;
 			buildPhases = (
-				E03AB5375E2A0105D7C52F4C /* Check Pods Manifest.lock */,
 				DD342B4C19A140EE00219F77 /* Sources */,
 				DD342B4D19A140EE00219F77 /* Frameworks */,
 				DD342B4E19A140EE00219F77 /* Resources */,
 				DDC2471919A1C3B40054B0C0 /* Embed Frameworks */,
-				75F39693BBF5C90FFDC01998 /* Embed Pods Frameworks */,
-				E701C4F0292AE0B9460ADB36 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -350,10 +341,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DDC2471D19A1C3B40054B0C0 /* Build configuration list for PBXNativeTarget "MapboxGeocoder" */;
 			buildPhases = (
+				3887C55B5640373246216A27 /* Check Pods Manifest.lock */,
 				DDC246FF19A1C3B40054B0C0 /* Sources */,
 				DDC2470019A1C3B40054B0C0 /* Frameworks */,
 				DDC2470119A1C3B40054B0C0 /* Headers */,
 				DDC2470219A1C3B40054B0C0 /* Resources */,
+				4A3AAF9E067CC264E7F8A998 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -517,19 +510,34 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxGeocoderTests/Pods-MapboxGeocoderTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		75F39693BBF5C90FFDC01998 /* Embed Pods Frameworks */ = {
+		3887C55B5640373246216A27 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		4A3AAF9E067CC264E7F8A998 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxGeocoder/Pods-MapboxGeocoder-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CD3F1CAEDE243BEE7EC3EFEF /* Embed Pods Frameworks */ = {
@@ -545,36 +553,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxGeocoderTests/Pods-MapboxGeocoderTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E03AB5375E2A0105D7C52F4C /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		E701C4F0292AE0B9460ADB36 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -730,7 +708,6 @@
 		};
 		DD342B6D19A140EE00219F77 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A7FEE3C3AC9D553F9763CB06 /* Pods.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -743,7 +720,6 @@
 		};
 		DD342B6E19A140EE00219F77 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CC09570CD1A6D11014400590 /* Pods.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -756,6 +732,7 @@
 		};
 		DDC2471E19A1C3B40054B0C0 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B4B7718C3CC6CB35C1916D3E /* Pods-MapboxGeocoder.debug.xcconfig */;
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -779,6 +756,7 @@
 		};
 		DDC2471F19A1C3B40054B0C0 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6B55078E561746475518C5B0 /* Pods-MapboxGeocoder.release.xcconfig */;
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;

--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,15 @@
 platform :ios, '8.0'
 use_frameworks!
 
-pod 'NBNRequestKit', :git => 'https://github.com/1ec5/RequestKit.git', :branch => 'mapbox-podspec'
+def shared_pods
+  pod 'NBNRequestKit', :git => 'https://github.com/1ec5/RequestKit.git', :branch => 'mapbox-podspec'
+end
+
+target 'MapboxGeocoder' do
+  shared_pods
+end
 
 target 'MapboxGeocoderTests' do
   pod 'Nocilla'
+  shared_pods
 end


### PR DESCRIPTION
Moves the Podfile to individually named targets, as defined in the Xcode project. This is required for [CocoaPods 1.0.0](http://blog.cocoapods.org/CocoaPods-1.0/).

Refs https://github.com/mapbox/MapboxDirections.swift/pull/35
/cc @1ec5