### PR TITLE
Support concurrent requests

### DIFF
--- a/MapboxGeocoderTests/ForwardGeocodingTests.swift
+++ b/MapboxGeocoderTests/ForwardGeocodingTests.swift
@@ -23,16 +23,17 @@ class ForwardGeocodingTests: XCTestCase {
         
         let geocoder = MBGeocoder(accessToken: BogusToken)
         var addressPlacemark: MBPlacemark! = nil
-        geocoder.geocodeAddressString("1600 pennsylvania ave nw", inCountries: ["CA"]) { (placemarks, error) in
+        let task = geocoder.geocodeAddressString("1600 pennsylvania ave nw", inCountries: ["CA"]) { (placemarks, error) in
             XCTAssertEqual(placemarks?.count, 5, "forward geocode should have 5 results")
             addressPlacemark = placemarks![0]
             
             expectation.fulfill()
         }
+        XCTAssertNotNil(task)
         
         waitForExpectationsWithTimeout(1) { (error) in
             XCTAssertNil(error, "Error: \(error)")
-            XCTAssertFalse(geocoder.geocoding)
+            XCTAssertEqual(task?.state, .Completed)
         }
         
         XCTAssertEqual(addressPlacemark.description, "Pennsylvania Ave, Stellarton, Nova Scotia B0K 1S0, Canada", "forward geocode should populate description")
@@ -63,14 +64,15 @@ class ForwardGeocodingTests: XCTestCase {
         
         let expection = expectationWithDescription("forward geocode execute completion handler for invalid query")
         let geocoder = MBGeocoder(accessToken: BogusToken)
-        geocoder.geocodeAddressString("Sandy Island, New Caledonia", withAllowedScopes: [.AdministrativeArea, .Place, .Locality, .PointOfInterest], inCountries: ["FR"]) { (placemarks, error) in
+        let task = geocoder.geocodeAddressString("Sandy Island, New Caledonia", withAllowedScopes: [.AdministrativeArea, .Place, .Locality, .PointOfInterest], inCountries: ["FR"]) { (placemarks, error) in
             XCTAssertEqual(placemarks?.count, 0, "forward geocode should return no results for invalid query")
             expection.fulfill()
         }
+        XCTAssertNotNil(task)
         
         waitForExpectationsWithTimeout(1) { (error) in
             XCTAssertNil(error, "Error: \(error)")
-            XCTAssertFalse(geocoder.geocoding)
+            XCTAssertEqual(task?.state, .Completed)
         }
     }
 }

--- a/MapboxGeocoderTests/ReverseGeocodingTests.swift
+++ b/MapboxGeocoderTests/ReverseGeocodingTests.swift
@@ -25,7 +25,7 @@ class ReverseGeocodingTests: XCTestCase {
         let geocoder = MBGeocoder(accessToken: BogusToken)
         var addressPlacemark: MBPlacemark! = nil
         var placePlacemark: MBPlacemark! = nil
-        geocoder.reverseGeocodeLocation(
+        let task = geocoder.reverseGeocodeLocation(
           CLLocation(latitude: 37.13284000, longitude: -95.78558000)) { (placemarks, error) in
             XCTAssertEqual(placemarks?.count, 5, "reverse geocode should have 5 results")
             addressPlacemark = placemarks![0]
@@ -33,10 +33,11 @@ class ReverseGeocodingTests: XCTestCase {
             
             expectation.fulfill()
         }
+        XCTAssertNotNil(task)
 
         waitForExpectationsWithTimeout(1) { (error) in
             XCTAssertNil(error, "Error: \(error)")
-            XCTAssertFalse(geocoder.geocoding)
+            XCTAssertEqual(task?.state, .Completed)
         }
         
         XCTAssertEqual(addressPlacemark.description, "3099 3100 Rd, Independence, Kansas 67301, United States", "reverse geocode should populate description")
@@ -76,14 +77,15 @@ class ReverseGeocodingTests: XCTestCase {
         
         let expection = expectationWithDescription("reverse geocode execute completion handler for invalid query")
         let geocoder = MBGeocoder(accessToken: BogusToken)
-        geocoder.reverseGeocodeLocation(CLLocation(latitude: 0, longitude: 0)) { (placemarks, error) in
+        let task = geocoder.reverseGeocodeLocation(CLLocation(latitude: 0, longitude: 0)) { (placemarks, error) in
             XCTAssertEqual(placemarks?.count, 0, "reverse geocode should return no results for invalid query")
             expection.fulfill()
         }
+        XCTAssertNotNil(task)
 
         waitForExpectationsWithTimeout(1) { (error) in
             XCTAssertNil(error, "Error: \(error)")
-            XCTAssertFalse(geocoder.geocoding)
+            XCTAssertEqual(task?.state, .Completed)
         }
     }
 }


### PR DESCRIPTION
Allow client code to manage any number of running tasks. `cancelGeocode()` cancels all outstanding tasks.

Depends on nerdishbynature/RequestKit#13 and nerdishbynature/RequestKit#14.

/cc @tmcw