### PR TITLE
Forward geocode CNPostalAddress

### DIFF
--- a/MapboxGeocoder/MBGeocodeOptions.swift
+++ b/MapboxGeocoder/MBGeocodeOptions.swift
@@ -1,3 +1,5 @@
+import Contacts
+
 /**
  A structure that specifies the criteria for results returned by the Mapbox Geocoding API.
  
@@ -94,6 +96,17 @@ public class ForwardGeocodeOptions: GeocodeOptions {
      */
     public convenience init(query: String) {
         self.init(queries: [query])
+    }
+    
+    /**
+     Initializes a forward geocode options object with the given postal address object.
+     
+     - parameter postalAddress: A `CNPostalAddress` object to search for.
+     */
+    @available(iOS 9.0, *)
+    public convenience init(postalAddress: CNPostalAddress) {
+        let formattedAddress = CNPostalAddressFormatter().stringFromPostalAddress(postalAddress)
+        self.init(query: formattedAddress.stringByReplacingOccurrencesOfString("\n", withString: ", "))
     }
     
     override var params: [NSURLQueryItem] {


### PR DESCRIPTION
Added an initializer to ForwardGeocodeOptions that takes a postal address. Whereas Core Location’s `CLGeocoder.geocodeAddressDictionary(_:completionHandler:)` takes an Address Book–style address dictionary, ForwardGeocodeOptions takes a CNPostalAddress object. The Contacts framework is only available in iOS 9.0 and above, but it’s intended to be a replacement for the Address Book framework.

Fixes #2.

/cc @friedbunny