### PR TITLE
Fix Contacts framework loading crash on OS X

### DIFF
--- a/MapboxGeocoder/MapboxGeocoder.h
+++ b/MapboxGeocoder/MapboxGeocoder.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
+#import <Contacts/Contacts.h>
 
 FOUNDATION_EXPORT double MapboxGeocoderVersionNumber;
 


### PR DESCRIPTION
Fixed a crash loading the framework due to Contacts not being linked. The framework now includes the Contacts umbrella header, which means it probably won’t build against the iOS 8.x and OS X 10.10.x SDKs, but it’ll still deploy backwards to them.

/ref #41, #42
/cc @friedbunny