### PR TITLE
Support tvOS, watchOS

### DIFF
--- a/MapboxGeocoder.swift.podspec
+++ b/MapboxGeocoder.swift.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.summary      = "Mapbox Geocoding API for Swift and Objective-C."
 
   s.description  = <<-DESC
-  MapboxGeocoder.swift makes it easy to connect your iOS, OS X, or tvOS application to the Mapbox Geocoding API. MapboxGeocoder.swift exposes the power of the Carmen geocoder through a simple API similar to Core Location’s CLGeocoder.
+  MapboxGeocoder.swift makes it easy to connect your iOS, OS X, tvOS, or watchOS application to the Mapbox Geocoding API. MapboxGeocoder.swift exposes the power of the Carmen geocoder through a simple API similar to Core Location’s CLGeocoder.
                    DESC
 
   s.homepage     = "https://www.mapbox.com/geocoding/"

--- a/MapboxGeocoder.swift.podspec
+++ b/MapboxGeocoder.swift.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.summary      = "Mapbox Geocoding API for Swift and Objective-C."
 
   s.description  = <<-DESC
-  MapboxGeocoder.swift makes it easy to connect your iOS or OS X application to the Mapbox Geocoding API. MapboxGeocoder.swift exposes the power of the Carmen geocoder through a simple API similar to Core Location’s CLGeocoder.
+  MapboxGeocoder.swift makes it easy to connect your iOS, OS X, or tvOS application to the Mapbox Geocoding API. MapboxGeocoder.swift exposes the power of the Carmen geocoder through a simple API similar to Core Location’s CLGeocoder.
                    DESC
 
   s.homepage     = "https://www.mapbox.com/geocoding/"

--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -47,6 +47,13 @@
 		DA5170E31CF2542B00CD6DCF /* forward_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = DA210BAE1CB4C5A7008088FD /* forward_invalid.json */; };
 		DA5170E41CF2542B00CD6DCF /* reverse_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = DDF1E85B1BD70E4C00C40C78 /* reverse_valid.json */; };
 		DA5170E51CF2542B00CD6DCF /* reverse_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = DDF1E85A1BD70E4C00C40C78 /* reverse_invalid.json */; };
+		DA5170F31CF2582F00CD6DCF /* MapboxGeocoder.h in Headers */ = {isa = PBXBuildFile; fileRef = DDC229581A36073B006BE405 /* MapboxGeocoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA5170F41CF2582F00CD6DCF /* MBGeocodeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2EC05D1CED732F00D4BA5D /* MBGeocodeOptions.swift */; };
+		DA5170F51CF2582F00CD6DCF /* MBGeocoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC229591A36073B006BE405 /* MBGeocoder.swift */; };
+		DA5170F61CF2582F00CD6DCF /* MBPlacemark.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2E03EF1CB0FDB400D1269A /* MBPlacemark.swift */; };
+		DA5170F71CF2582F00CD6DCF /* MBPlacemarkScope.h in Headers */ = {isa = PBXBuildFile; fileRef = DA29C8DE1CEBE90200E48A61 /* MBPlacemarkScope.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA5170F81CF2582F00CD6DCF /* MBPlacemarkScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2EC05B1CED72E900D4BA5D /* MBPlacemarkScope.swift */; };
+		DA5170F91CF2582F00CD6DCF /* MBRectangularRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2E03F11CB0FE0200D1269A /* MBRectangularRegion.swift */; };
 		DA701C011CB1292C00B0E520 /* GeocoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA701C001CB1292C00B0E520 /* GeocoderTests.swift */; };
 		DD342B5619A140EE00219F77 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD342B5519A140EE00219F77 /* AppDelegate.swift */; };
 		DD342B5819A140EE00219F77 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD342B5719A140EE00219F77 /* ViewController.swift */; };
@@ -155,6 +162,7 @@
 		DA51709F1CF1B18F00CD6DCF /* MapboxGeocoderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxGeocoderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5170C11CF253EE00CD6DCF /* MapboxGeocoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxGeocoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5170CA1CF253EE00CD6DCF /* MapboxGeocoderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxGeocoderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA5170EB1CF2581900CD6DCF /* MapboxGeocoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxGeocoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA701C001CB1292C00B0E520 /* GeocoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeocoderTests.swift; sourceTree = "<group>"; };
 		DD342B5019A140EE00219F77 /* Geocoder (Swift).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Geocoder (Swift).app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD342B5419A140EE00219F77 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -207,6 +215,13 @@
 			files = (
 				DA5170CB1CF253EE00CD6DCF /* MapboxGeocoder.framework in Frameworks */,
 				0C025346C32B474C347C71BD /* Pods_MapboxGeocoderTVTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA5170E71CF2581900CD6DCF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -277,6 +292,7 @@
 				DA51709F1CF1B18F00CD6DCF /* MapboxGeocoderTests.xctest */,
 				DA5170C11CF253EE00CD6DCF /* MapboxGeocoder.framework */,
 				DA5170CA1CF253EE00CD6DCF /* MapboxGeocoderTests.xctest */,
+				DA5170EB1CF2581900CD6DCF /* MapboxGeocoder.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -401,6 +417,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DA5170E81CF2581900CD6DCF /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA5170F31CF2582F00CD6DCF /* MapboxGeocoder.h in Headers */,
+				DA5170F71CF2582F00CD6DCF /* MBPlacemarkScope.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DDC2470119A1C3B40054B0C0 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -490,6 +515,24 @@
 			productName = MapboxGeocoderTVTests;
 			productReference = DA5170CA1CF253EE00CD6DCF /* MapboxGeocoderTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		DA5170EA1CF2581900CD6DCF /* MapboxGeocoderWatch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA5170F21CF2581900CD6DCF /* Build configuration list for PBXNativeTarget "MapboxGeocoderWatch" */;
+			buildPhases = (
+				DA5170E61CF2581900CD6DCF /* Sources */,
+				DA5170E71CF2581900CD6DCF /* Frameworks */,
+				DA5170E81CF2581900CD6DCF /* Headers */,
+				DA5170E91CF2581900CD6DCF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MapboxGeocoderWatch;
+			productName = MapboxGeocoderWatch;
+			productReference = DA5170EB1CF2581900CD6DCF /* MapboxGeocoder.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 		DD342B4F19A140EE00219F77 /* Example (Swift) */ = {
 			isa = PBXNativeTarget;
@@ -592,6 +635,9 @@
 					DA5170C91CF253EE00CD6DCF = {
 						CreatedOnToolsVersion = 7.3.1;
 					};
+					DA5170EA1CF2581900CD6DCF = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
 					DD342B4F19A140EE00219F77 = {
 						CreatedOnToolsVersion = 6.0;
 					};
@@ -627,6 +673,7 @@
 				DA51709E1CF1B18F00CD6DCF /* MapboxGeocoderMacTests */,
 				DA5170C01CF253EE00CD6DCF /* MapboxGeocoderTV */,
 				DA5170C91CF253EE00CD6DCF /* MapboxGeocoderTVTests */,
+				DA5170EA1CF2581900CD6DCF /* MapboxGeocoderWatch */,
 			);
 		};
 /* End PBXProject section */
@@ -665,6 +712,13 @@
 				DA5170E31CF2542B00CD6DCF /* forward_invalid.json in Resources */,
 				DA5170E51CF2542B00CD6DCF /* reverse_invalid.json in Resources */,
 				DA5170E41CF2542B00CD6DCF /* reverse_valid.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA5170E91CF2581900CD6DCF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -882,6 +936,18 @@
 				DA5170E11CF2542800CD6DCF /* ReverseGeocodingTests.swift in Sources */,
 				DA5170DF1CF2542800CD6DCF /* GeocoderTests.swift in Sources */,
 				DA5170E01CF2542800CD6DCF /* ForwardGeocodingTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA5170E61CF2581900CD6DCF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA5170F91CF2582F00CD6DCF /* MBRectangularRegion.swift in Sources */,
+				DA5170F61CF2582F00CD6DCF /* MBPlacemark.swift in Sources */,
+				DA5170F51CF2582F00CD6DCF /* MBGeocoder.swift in Sources */,
+				DA5170F81CF2582F00CD6DCF /* MBPlacemarkScope.swift in Sources */,
+				DA5170F41CF2582F00CD6DCF /* MBGeocodeOptions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1134,6 +1200,59 @@
 			};
 			name = Release;
 		};
+		DA5170F01CF2581900CD6DCF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = MapboxGeocoder/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGeocoder;
+				PRODUCT_NAME = MapboxGeocoder;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		DA5170F11CF2581900CD6DCF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = MapboxGeocoder/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGeocoder;
+				PRODUCT_NAME = MapboxGeocoder;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
 		DD342B6A19A140EE00219F77 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1380,6 +1499,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		DA5170F21CF2581900CD6DCF /* Build configuration list for PBXNativeTarget "MapboxGeocoderWatch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA5170F01CF2581900CD6DCF /* Debug */,
+				DA5170F11CF2581900CD6DCF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 		DD342B4B19A140EE00219F77 /* Build configuration list for PBXProject "MapboxGeocoder" */ = {
 			isa = XCConfigurationList;

--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C025346C32B474C347C71BD /* Pods_MapboxGeocoderTVTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB3C49168FF11C0E7040FD82 /* Pods_MapboxGeocoderTVTests.framework */; };
 		7CA566EF62920C25D486FD70 /* Pods_MapboxGeocoderMacTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46A2AC60FDF3B534284CDB36 /* Pods_MapboxGeocoderMacTests.framework */; };
 		86AE592691CECC25DE17D833 /* Pods_MapboxGeocoderTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72CB04596652E3835ED4FC60 /* Pods_MapboxGeocoderTests.framework */; };
 		DA210BAB1CB4BE73008088FD /* ForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA210BAA1CB4BE73008088FD /* ForwardGeocodingTests.swift */; };
@@ -31,6 +32,21 @@
 		DA5170B91CF1B1F900CD6DCF /* forward_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = DA210BAE1CB4C5A7008088FD /* forward_invalid.json */; };
 		DA5170BA1CF1B1F900CD6DCF /* reverse_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = DDF1E85B1BD70E4C00C40C78 /* reverse_valid.json */; };
 		DA5170BB1CF1B1F900CD6DCF /* reverse_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = DDF1E85A1BD70E4C00C40C78 /* reverse_invalid.json */; };
+		DA5170CB1CF253EE00CD6DCF /* MapboxGeocoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5170C11CF253EE00CD6DCF /* MapboxGeocoder.framework */; };
+		DA5170D81CF2541C00CD6DCF /* MapboxGeocoder.h in Headers */ = {isa = PBXBuildFile; fileRef = DDC229581A36073B006BE405 /* MapboxGeocoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA5170D91CF2541C00CD6DCF /* MBGeocodeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2EC05D1CED732F00D4BA5D /* MBGeocodeOptions.swift */; };
+		DA5170DA1CF2541C00CD6DCF /* MBGeocoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC229591A36073B006BE405 /* MBGeocoder.swift */; };
+		DA5170DB1CF2541C00CD6DCF /* MBPlacemark.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2E03EF1CB0FDB400D1269A /* MBPlacemark.swift */; };
+		DA5170DC1CF2541C00CD6DCF /* MBPlacemarkScope.h in Headers */ = {isa = PBXBuildFile; fileRef = DA29C8DE1CEBE90200E48A61 /* MBPlacemarkScope.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA5170DD1CF2541C00CD6DCF /* MBPlacemarkScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2EC05B1CED72E900D4BA5D /* MBPlacemarkScope.swift */; };
+		DA5170DE1CF2541C00CD6DCF /* MBRectangularRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2E03F11CB0FE0200D1269A /* MBRectangularRegion.swift */; };
+		DA5170DF1CF2542800CD6DCF /* GeocoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA701C001CB1292C00B0E520 /* GeocoderTests.swift */; };
+		DA5170E01CF2542800CD6DCF /* ForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA210BAA1CB4BE73008088FD /* ForwardGeocodingTests.swift */; };
+		DA5170E11CF2542800CD6DCF /* ReverseGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF1E84C1BD6F7BA00C40C78 /* ReverseGeocodingTests.swift */; };
+		DA5170E21CF2542B00CD6DCF /* forward_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = DA210BAC1CB4BFF7008088FD /* forward_valid.json */; };
+		DA5170E31CF2542B00CD6DCF /* forward_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = DA210BAE1CB4C5A7008088FD /* forward_invalid.json */; };
+		DA5170E41CF2542B00CD6DCF /* reverse_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = DDF1E85B1BD70E4C00C40C78 /* reverse_valid.json */; };
+		DA5170E51CF2542B00CD6DCF /* reverse_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = DDF1E85A1BD70E4C00C40C78 /* reverse_invalid.json */; };
 		DA701C011CB1292C00B0E520 /* GeocoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA701C001CB1292C00B0E520 /* GeocoderTests.swift */; };
 		DD342B5619A140EE00219F77 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD342B5519A140EE00219F77 /* AppDelegate.swift */; };
 		DD342B5819A140EE00219F77 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD342B5719A140EE00219F77 /* ViewController.swift */; };
@@ -55,6 +71,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = DA5170951CF1B18F00CD6DCF;
 			remoteInfo = MapboxGeocoderMac;
+		};
+		DA5170CC1CF253EE00CD6DCF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DD342B4819A140EE00219F77 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA5170C01CF253EE00CD6DCF;
+			remoteInfo = MapboxGeocoderTV;
 		};
 		DD1772B51A360BAF00C40FDC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -113,6 +136,8 @@
 
 /* Begin PBXFileReference section */
 		1D586B54B6C2205A34468E44 /* Pods-MapboxGeocoderTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxGeocoderTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxGeocoderTests/Pods-MapboxGeocoderTests.debug.xcconfig"; sourceTree = "<group>"; };
+		296697D5C455A31511CF9C08 /* Pods-MapboxGeocoderTVTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxGeocoderTVTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxGeocoderTVTests/Pods-MapboxGeocoderTVTests.debug.xcconfig"; sourceTree = "<group>"; };
+		2F5FC0ED83E6908E7104787A /* Pods-MapboxGeocoderTVTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxGeocoderTVTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxGeocoderTVTests/Pods-MapboxGeocoderTVTests.release.xcconfig"; sourceTree = "<group>"; };
 		46A2AC60FDF3B534284CDB36 /* Pods_MapboxGeocoderMacTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxGeocoderMacTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		72CB04596652E3835ED4FC60 /* Pods_MapboxGeocoderTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxGeocoderTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8C8C881DE859EB667533E864 /* Pods-MapboxGeocoderMacTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxGeocoderMacTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxGeocoderMacTests/Pods-MapboxGeocoderMacTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -128,6 +153,8 @@
 		DA2EC05D1CED732F00D4BA5D /* MBGeocodeOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBGeocodeOptions.swift; sourceTree = "<group>"; };
 		DA5170961CF1B18F00CD6DCF /* MapboxGeocoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxGeocoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA51709F1CF1B18F00CD6DCF /* MapboxGeocoderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxGeocoderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA5170C11CF253EE00CD6DCF /* MapboxGeocoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxGeocoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA5170CA1CF253EE00CD6DCF /* MapboxGeocoderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxGeocoderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA701C001CB1292C00B0E520 /* GeocoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeocoderTests.swift; sourceTree = "<group>"; };
 		DD342B5019A140EE00219F77 /* Geocoder (Swift).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Geocoder (Swift).app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD342B5419A140EE00219F77 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -148,6 +175,7 @@
 		DDF1E84E1BD6F7BA00C40C78 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DDF1E85A1BD70E4C00C40C78 /* reverse_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = reverse_invalid.json; sourceTree = "<group>"; };
 		DDF1E85B1BD70E4C00C40C78 /* reverse_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = reverse_valid.json; sourceTree = "<group>"; };
+		EB3C49168FF11C0E7040FD82 /* Pods_MapboxGeocoderTVTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxGeocoderTVTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,6 +191,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				7CA566EF62920C25D486FD70 /* Pods_MapboxGeocoderMacTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA5170BD1CF253EE00CD6DCF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA5170C71CF253EE00CD6DCF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA5170CB1CF253EE00CD6DCF /* MapboxGeocoder.framework in Frameworks */,
+				0C025346C32B474C347C71BD /* Pods_MapboxGeocoderTVTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -205,6 +249,7 @@
 			children = (
 				72CB04596652E3835ED4FC60 /* Pods_MapboxGeocoderTests.framework */,
 				46A2AC60FDF3B534284CDB36 /* Pods_MapboxGeocoderMacTests.framework */,
+				EB3C49168FF11C0E7040FD82 /* Pods_MapboxGeocoderTVTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -230,6 +275,8 @@
 				DDF1E84A1BD6F7BA00C40C78 /* MapboxGeocoderTests.xctest */,
 				DA5170961CF1B18F00CD6DCF /* MapboxGeocoder.framework */,
 				DA51709F1CF1B18F00CD6DCF /* MapboxGeocoderTests.xctest */,
+				DA5170C11CF253EE00CD6DCF /* MapboxGeocoder.framework */,
+				DA5170CA1CF253EE00CD6DCF /* MapboxGeocoderTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -327,6 +374,8 @@
 				C166681A922E6E205D5040F9 /* Pods-MapboxGeocoderTests.release.xcconfig */,
 				BE56DFB939470771CAC74338 /* Pods-MapboxGeocoderMacTests.debug.xcconfig */,
 				8C8C881DE859EB667533E864 /* Pods-MapboxGeocoderMacTests.release.xcconfig */,
+				296697D5C455A31511CF9C08 /* Pods-MapboxGeocoderTVTests.debug.xcconfig */,
+				2F5FC0ED83E6908E7104787A /* Pods-MapboxGeocoderTVTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -340,6 +389,15 @@
 			files = (
 				DA5170AD1CF1B1DB00CD6DCF /* MapboxGeocoder.h in Headers */,
 				DA5170B11CF1B1E000CD6DCF /* MBPlacemarkScope.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA5170BE1CF253EE00CD6DCF /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA5170D81CF2541C00CD6DCF /* MapboxGeocoder.h in Headers */,
+				DA5170DC1CF2541C00CD6DCF /* MBPlacemarkScope.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -392,6 +450,45 @@
 			name = MapboxGeocoderMacTests;
 			productName = MapboxGeocoderMacTests;
 			productReference = DA51709F1CF1B18F00CD6DCF /* MapboxGeocoderTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		DA5170C01CF253EE00CD6DCF /* MapboxGeocoderTV */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA5170D61CF253EE00CD6DCF /* Build configuration list for PBXNativeTarget "MapboxGeocoderTV" */;
+			buildPhases = (
+				DA5170BC1CF253EE00CD6DCF /* Sources */,
+				DA5170BD1CF253EE00CD6DCF /* Frameworks */,
+				DA5170BE1CF253EE00CD6DCF /* Headers */,
+				DA5170BF1CF253EE00CD6DCF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MapboxGeocoderTV;
+			productName = MapboxGeocoderTV;
+			productReference = DA5170C11CF253EE00CD6DCF /* MapboxGeocoder.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		DA5170C91CF253EE00CD6DCF /* MapboxGeocoderTVTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA5170D71CF253EE00CD6DCF /* Build configuration list for PBXNativeTarget "MapboxGeocoderTVTests" */;
+			buildPhases = (
+				F37C4A0BDB9868CD695600A9 /* 📦 Check Pods Manifest.lock */,
+				DA5170C61CF253EE00CD6DCF /* Sources */,
+				DA5170C71CF253EE00CD6DCF /* Frameworks */,
+				DA5170C81CF253EE00CD6DCF /* Resources */,
+				B5DADF6B81D86CCDCD201D0B /* 📦 Embed Pods Frameworks */,
+				FF67696B342B317639DDF7C6 /* 📦 Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DA5170CD1CF253EE00CD6DCF /* PBXTargetDependency */,
+			);
+			name = MapboxGeocoderTVTests;
+			productName = MapboxGeocoderTVTests;
+			productReference = DA5170CA1CF253EE00CD6DCF /* MapboxGeocoderTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		DD342B4F19A140EE00219F77 /* Example (Swift) */ = {
@@ -489,6 +586,12 @@
 					DA51709E1CF1B18F00CD6DCF = {
 						CreatedOnToolsVersion = 7.3.1;
 					};
+					DA5170C01CF253EE00CD6DCF = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
+					DA5170C91CF253EE00CD6DCF = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
 					DD342B4F19A140EE00219F77 = {
 						CreatedOnToolsVersion = 6.0;
 					};
@@ -522,6 +625,8 @@
 				DDF1E8491BD6F7BA00C40C78 /* MapboxGeocoderTests */,
 				DA5170951CF1B18F00CD6DCF /* MapboxGeocoderMac */,
 				DA51709E1CF1B18F00CD6DCF /* MapboxGeocoderMacTests */,
+				DA5170C01CF253EE00CD6DCF /* MapboxGeocoderTV */,
+				DA5170C91CF253EE00CD6DCF /* MapboxGeocoderTVTests */,
 			);
 		};
 /* End PBXProject section */
@@ -542,6 +647,24 @@
 				DA5170B91CF1B1F900CD6DCF /* forward_invalid.json in Resources */,
 				DA5170BB1CF1B1F900CD6DCF /* reverse_invalid.json in Resources */,
 				DA5170BA1CF1B1F900CD6DCF /* reverse_valid.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA5170BF1CF253EE00CD6DCF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA5170C81CF253EE00CD6DCF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA5170E21CF2542B00CD6DCF /* forward_valid.json in Resources */,
+				DA5170E31CF2542B00CD6DCF /* forward_invalid.json in Resources */,
+				DA5170E51CF2542B00CD6DCF /* reverse_invalid.json in Resources */,
+				DA5170E41CF2542B00CD6DCF /* reverse_valid.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -640,6 +763,21 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		B5DADF6B81D86CCDCD201D0B /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxGeocoderTVTests/Pods-MapboxGeocoderTVTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		BDD759BF2453F48BD4C36923 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -670,6 +808,36 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		F37C4A0BDB9868CD695600A9 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		FF67696B342B317639DDF7C6 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxGeocoderTVTests/Pods-MapboxGeocoderTVTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -692,6 +860,28 @@
 				DA5170B61CF1B1EF00CD6DCF /* ReverseGeocodingTests.swift in Sources */,
 				DA5170B41CF1B1EF00CD6DCF /* GeocoderTests.swift in Sources */,
 				DA5170B51CF1B1EF00CD6DCF /* ForwardGeocodingTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA5170BC1CF253EE00CD6DCF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA5170DE1CF2541C00CD6DCF /* MBRectangularRegion.swift in Sources */,
+				DA5170DB1CF2541C00CD6DCF /* MBPlacemark.swift in Sources */,
+				DA5170DA1CF2541C00CD6DCF /* MBGeocoder.swift in Sources */,
+				DA5170DD1CF2541C00CD6DCF /* MBPlacemarkScope.swift in Sources */,
+				DA5170D91CF2541C00CD6DCF /* MBGeocodeOptions.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA5170C61CF253EE00CD6DCF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA5170E11CF2542800CD6DCF /* ReverseGeocodingTests.swift in Sources */,
+				DA5170DF1CF2542800CD6DCF /* GeocoderTests.swift in Sources */,
+				DA5170E01CF2542800CD6DCF /* ForwardGeocodingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -744,6 +934,11 @@
 			target = DA5170951CF1B18F00CD6DCF /* MapboxGeocoderMac */;
 			targetProxy = DA5170A11CF1B18F00CD6DCF /* PBXContainerItemProxy */;
 		};
+		DA5170CD1CF253EE00CD6DCF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA5170C01CF253EE00CD6DCF /* MapboxGeocoderTV */;
+			targetProxy = DA5170CC1CF253EE00CD6DCF /* PBXContainerItemProxy */;
+		};
 		DD1772B61A360BAF00C40FDC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DDC2470319A1C3B40054B0C0 /* MapboxGeocoder */;
@@ -781,7 +976,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
 				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = "$(SRCROOT)/MapboxGeocoder/Info.plist";
+				INFOPLIST_FILE = MapboxGeocoder/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGeocoder;
@@ -808,7 +1003,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
 				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = "$(SRCROOT)/MapboxGeocoder/Info.plist";
+				INFOPLIST_FILE = MapboxGeocoder/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGeocoder;
@@ -852,6 +1047,90 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGeocoderTests;
 				PRODUCT_NAME = MapboxGeocoderTests;
 				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		DA5170D21CF253EE00CD6DCF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = MapboxGeocoder/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGeocoder;
+				PRODUCT_NAME = MapboxGeocoder;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		DA5170D31CF253EE00CD6DCF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = MapboxGeocoder/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGeocoder;
+				PRODUCT_NAME = MapboxGeocoder;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		DA5170D41CF253EE00CD6DCF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 296697D5C455A31511CF9C08 /* Pods-MapboxGeocoderTVTests.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = MapboxGeocoderTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGeocoderTests;
+				PRODUCT_NAME = MapboxGeocoderTests;
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		DA5170D51CF253EE00CD6DCF /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2F5FC0ED83E6908E7104787A /* Pods-MapboxGeocoderTVTests.release.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = MapboxGeocoderTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxGeocoderTests;
+				PRODUCT_NAME = MapboxGeocoderTests;
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};
@@ -1080,6 +1359,24 @@
 			buildConfigurations = (
 				DA5170A91CF1B18F00CD6DCF /* Debug */,
 				DA5170AA1CF1B18F00CD6DCF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DA5170D61CF253EE00CD6DCF /* Build configuration list for PBXNativeTarget "MapboxGeocoderTV" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA5170D21CF253EE00CD6DCF /* Debug */,
+				DA5170D31CF253EE00CD6DCF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DA5170D71CF253EE00CD6DCF /* Build configuration list for PBXNativeTarget "MapboxGeocoderTVTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA5170D41CF253EE00CD6DCF /* Debug */,
+				DA5170D51CF253EE00CD6DCF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/MapboxGeocoder tvOS.xcscheme
+++ b/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/MapboxGeocoder tvOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA5170C01CF253EE00CD6DCF"
+               BuildableName = "MapboxGeocoder.framework"
+               BlueprintName = "MapboxGeocoderTV"
+               ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA5170C91CF253EE00CD6DCF"
+               BuildableName = "MapboxGeocoderTests.xctest"
+               BlueprintName = "MapboxGeocoderTVTests"
+               ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA5170C01CF253EE00CD6DCF"
+            BuildableName = "MapboxGeocoder.framework"
+            BlueprintName = "MapboxGeocoderTV"
+            ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA5170C01CF253EE00CD6DCF"
+            BuildableName = "MapboxGeocoder.framework"
+            BlueprintName = "MapboxGeocoderTV"
+            ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA5170C01CF253EE00CD6DCF"
+            BuildableName = "MapboxGeocoder.framework"
+            BlueprintName = "MapboxGeocoderTV"
+            ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/MapboxGeocoder watchOS.xcscheme
+++ b/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/MapboxGeocoder watchOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA5170EA1CF2581900CD6DCF"
+               BuildableName = "MapboxGeocoderWatch.framework"
+               BlueprintName = "MapboxGeocoderWatch"
+               ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA5170EA1CF2581900CD6DCF"
+            BuildableName = "MapboxGeocoderWatch.framework"
+            BlueprintName = "MapboxGeocoderWatch"
+            ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA5170EA1CF2581900CD6DCF"
+            BuildableName = "MapboxGeocoderWatch.framework"
+            BlueprintName = "MapboxGeocoderWatch"
+            ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MapboxGeocoder/MBGeocodeOptions.swift
+++ b/MapboxGeocoder/MBGeocodeOptions.swift
@@ -1,4 +1,6 @@
-import Contacts
+#if !os(tvOS)
+    import Contacts
+#endif
 
 /**
  A structure that specifies the criteria for results returned by the Mapbox Geocoding API.
@@ -98,6 +100,7 @@ public class ForwardGeocodeOptions: GeocodeOptions {
         self.init(queries: [query])
     }
     
+    #if !os(tvOS)
     /**
      Initializes a forward geocode options object with the given postal address object.
      
@@ -108,6 +111,7 @@ public class ForwardGeocodeOptions: GeocodeOptions {
         let formattedAddress = CNPostalAddressFormatter().stringFromPostalAddress(postalAddress)
         self.init(query: formattedAddress.stringByReplacingOccurrencesOfString("\n", withString: ", "))
     }
+    #endif
     
     override var params: [NSURLQueryItem] {
         var params = super.params

--- a/MapboxGeocoder/MBPlacemark.swift
+++ b/MapboxGeocoder/MBPlacemark.swift
@@ -1,4 +1,6 @@
-import Contacts
+#if !os(tvOS)
+    import Contacts
+#endif
 
 // MARK: Postal Address Properties
 
@@ -221,6 +223,7 @@ public class Placemark: NSObject, NSCopying, NSSecureCoding {
         return nil
     }
     
+    #if !os(tvOS)
     /**
      The placemark’s postal address.
      
@@ -230,6 +233,7 @@ public class Placemark: NSObject, NSCopying, NSSecureCoding {
     public var postalAddress: CNPostalAddress? {
         return nil
     }
+    #endif
     
     /**
      A dictionary containing the Contacts keys and values for the placemark.
@@ -424,6 +428,7 @@ public class GeocodedPlacemark: Placemark {
         return scope == .Address ? lines : Array(lines.suffixFrom(1))
     }
     
+    #if !os(tvOS)
     @available(iOS 9.0, OSX 10.11, *)
     public override var postalAddress: CNPostalAddress? {
         let postalAddress = CNMutablePostalAddress()
@@ -452,6 +457,7 @@ public class GeocodedPlacemark: Placemark {
         
         return postalAddress
     }
+    #endif
     
     public override var addressDictionary: [NSObject: AnyObject]? {
         var addressDictionary: [String: AnyObject] = [:]

--- a/MapboxGeocoder/MapboxGeocoder.h
+++ b/MapboxGeocoder/MapboxGeocoder.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
+#if !TARGET_OS_TV
 #import <Contacts/Contacts.h>
+#endif
 
 FOUNDATION_EXPORT double MapboxGeocoderVersionNumber;
 

--- a/Podfile
+++ b/Podfile
@@ -20,3 +20,8 @@ target 'MapboxGeocoderMacTests' do
   platform :osx, '10.10'
   shared_test_pods
 end
+
+target 'MapboxGeocoderTVTests' do
+  platform :tvos, '9.0'
+  shared_test_pods
+end

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [📱&nbsp;![iOS Build Status](https://www.bitrise.io/app/6cae401ec4c1d406.svg?token=MJnXK0c2x2tmTnmHSPtcFA&branch=master)](https://www.bitrise.io/app/6cae401ec4c1d406) &nbsp;&nbsp;&nbsp;
 [🖥💻&nbsp;![OS X Build Status](https://www.bitrise.io/app/8413a6e577d6aa9a.svg?token=N1agv0mw75SOE_SykliueQ&branch=master)](https://www.bitrise.io/app/8413a6e577d6aa9a)
 
-MapboxGeocoder.swift makes it easy to connect your iOS, OS X, or tvOS application to the [Mapbox Geocoding API](https://www.mapbox.com/geocoding/). MapboxGeocoder.swift exposes the power of the [Carmen](https://github.com/mapbox/carmen) geocoder through a simple API similar to Core Location’s CLGeocoder.
+MapboxGeocoder.swift makes it easy to connect your iOS, OS X, tvOS, or watchOS application to the [Mapbox Geocoding API](https://www.mapbox.com/geocoding/). MapboxGeocoder.swift exposes the power of the [Carmen](https://github.com/mapbox/carmen) geocoder through a simple API similar to Core Location’s CLGeocoder.
 
 MapboxGeocoder.swift pairs well with [MapboxDirections.swift](https://github.com/mapbox/MapboxDirections.swift), [MapboxStatic.swift](https://github.com/mapbox/MapboxStatic.swift), and the [Mapbox iOS SDK](https://www.mapbox.com/ios-sdk/) or [OS X SDK](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/osx).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [📱&nbsp;![iOS Build Status](https://www.bitrise.io/app/6cae401ec4c1d406.svg?token=MJnXK0c2x2tmTnmHSPtcFA&branch=master)](https://www.bitrise.io/app/6cae401ec4c1d406) &nbsp;&nbsp;&nbsp;
 [🖥💻&nbsp;![OS X Build Status](https://www.bitrise.io/app/8413a6e577d6aa9a.svg?token=N1agv0mw75SOE_SykliueQ&branch=master)](https://www.bitrise.io/app/8413a6e577d6aa9a)
 
-MapboxGeocoder.swift makes it easy to connect your iOS or OS X application to the [Mapbox Geocoding API](https://www.mapbox.com/geocoding/). MapboxGeocoder.swift exposes the power of the [Carmen](https://github.com/mapbox/carmen) geocoder through a simple API similar to Core Location’s CLGeocoder.
+MapboxGeocoder.swift makes it easy to connect your iOS, OS X, or tvOS application to the [Mapbox Geocoding API](https://www.mapbox.com/geocoding/). MapboxGeocoder.swift exposes the power of the [Carmen](https://github.com/mapbox/carmen) geocoder through a simple API similar to Core Location’s CLGeocoder.
 
 MapboxGeocoder.swift pairs well with [MapboxDirections.swift](https://github.com/mapbox/MapboxDirections.swift), [MapboxStatic.swift](https://github.com/mapbox/MapboxStatic.swift), and the [Mapbox iOS SDK](https://www.mapbox.com/ios-sdk/) or [OS X SDK](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/osx).
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ _Forward geocoding_ takes a human-readable query, such as a place name or addres
 
 ```swift
 // main.swift
-import Contacts
+#if !os(tvOS)
+    import Contacts
+#endif
 
 let options = ForwardGeocodeOptions(query: "200 queen street")
 
@@ -79,17 +81,21 @@ let task = geocoder.geocode(options: options) { (placemarks, attribution, error)
     print("\(coordinate.latitude), \(coordinate.longitude)")
         // 45.270093, -66.050985
     
+    #if !os(tvOS)
     let formatter = CNPostalAddressFormatter()
     print(formatter.stringFromPostalAddress(placemark.postalAddress))
         // 200 Queen St
         // Saint John New Brunswick E2L 2X1
         // Canada
+    #endif
 }
 ```
 
 ```objc
 // main.m
+#if !TARGET_OS_TV
 @import Contacts;
+#endif
 
 MBForwardGeocodeOptions *options = [[MBForwardGeocodeOptions alloc] initWithQuery:@"200 queen street"];
 
@@ -112,11 +118,13 @@ NSURLSessionDataTask *task = [geocoder geocodeWithOptions:options
     NSLog(@"%f, %f", coordinate.latitude, coordinate.longitude);
         // 45.270093, -66.050985
     
+#if !TARGET_OS_TV
     CNPostalAddressFormatter *formatter = [[CNPostalAddressFormatter alloc] init];
     NSLog(@"%@", [formatter stringFromPostalAddress:placemark.postalAddress]);
         // 200 Queen St
         // Saint John New Brunswick E2L 2X1
         // Canada
+#endif
 }];
 ```
 


### PR DESCRIPTION
It’s been possible to use the pod in tvOS and watchOS since baf7dcf09067a72de41908035998560844dd9dab, although tvOS support broke when we added integration with the Contacts framework in #41 and #42. (Contacts is unavailable on tvOS. The breakage was fixed in #45.) To prevent similar breakage in the future, this PR adds tvOS and watchOS targets that can be built in CI.

/ref mapbox/MapboxStatic.swift#25
/cc @tmcw @friedbunny