### PR TITLE
Configure user agent string

### DIFF
--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -6,6 +6,57 @@ public let MBGeocoderErrorDomain = "MBGeocoderErrorDomain"
 /// The Mapbox access token specified in the main application bundle’s Info.plist.
 let defaultAccessToken = NSBundle.mainBundle().objectForInfoDictionaryKey("MGLMapboxAccessToken") as? String
 
+/// The user agent string for any HTTP requests performed directly within this library.
+let userAgent: String = {
+    var components: [String] = []
+    
+    if let appName = NSBundle.mainBundle().infoDictionary?["CFBundleName"] as? String ?? NSBundle.mainBundle().infoDictionary?["CFBundleIdentifier"] as? String {
+        let version = NSBundle.mainBundle().infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        components.append("\(appName)/\(version)")
+    }
+    
+    var libraryBundle: NSBundle? = NSBundle(forClass: Geocoder.self)
+    if libraryBundle?.infoDictionary?["CFBundlePackageType"] as? String != "FMWK" {
+        // For static frameworks, the class is contained in the application bundle rather than the framework bundle.
+        if let frameworkURL = libraryBundle?.privateFrameworksURL?.URLByAppendingPathComponent("Mapbox.framework") {
+            libraryBundle = NSBundle(URL: frameworkURL)
+        }
+    }
+    
+    if let libraryName = libraryBundle?.infoDictionary?["CFBundleName"] as? String, version = libraryBundle?.infoDictionary?["CFBundleShortVersionString"] as? String {
+        components.append("\(libraryName)/\(version)")
+    }
+    
+    let system: String
+    #if os(OSX)
+        system = "OS X"
+    #elseif os(iOS)
+        system = "iOS"
+    #elseif os(watchOS)
+        system = "watchOS"
+    #elseif os(tvOS)
+        system = "tvOS"
+    #elseif os(Linux)
+        system = "Linux"
+    #endif
+    let systemVersion = NSProcessInfo().operatingSystemVersion
+    components.append("\(system)/\(systemVersion.majorVersion).\(systemVersion.minorVersion).\(systemVersion.patchVersion)")
+    
+    let chip: String
+    #if arch(x86_64)
+        chip = "x86_64"
+    #elseif arch(arm)
+        chip = "arm"
+    #elseif arch(arm64)
+        chip = "arm64"
+    #elseif arch(i386)
+        chip = "i386"
+    #endif
+    components.append("(\(chip))")
+    
+    return components.joinWithSeparator(" ")
+}()
+
 extension NSCharacterSet {
     /**
      Returns the character set including the characters allowed in the “geocoding query” (file name) part of a Geocoding API URL request.
@@ -178,7 +229,9 @@ public class Geocoder: NSObject {
      - postcondition: The caller must resume the returned task.
      */
     private func dataTaskWithURL(url: NSURL, completionHandler: (json: AnyObject) -> Void, errorHandler: (error: NSError) -> Void) -> NSURLSessionDataTask {
-        return NSURLSession.sharedSession().dataTaskWithURL(url) { (data, response, error) in
+        let request = NSMutableURLRequest(URL: url)
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        return NSURLSession.sharedSession().dataTaskWithRequest(request) { (data, response, error) in
             var json: JSONDictionary = [:]
             if let data = data {
                 do {


### PR DESCRIPTION
When the Geocoder object sends a request, it sets the `User-Agent` HTTP header to a value of the form:

```
SanDiego/1.2.3 MapboxGeocoder/0.5.0 iOS/9.3.0 (x86_64)
```

This user agent string is based on the one used by the Mapbox iOS and OS X SDKs.

Fixes #25.

/cc @friedbunny