### PR TITLE
Rename RectangularRegion.containsCoordinate(_:)

### DIFF
--- a/MapboxGeocoder/MBRectangularRegion.swift
+++ b/MapboxGeocoder/MBRectangularRegion.swift
@@ -43,6 +43,13 @@ public class RectangularRegion: CLRegion {
      Returns a Boolean value indicating whether the bounding box contains the specified coordinate.
      */
     public func containsCoordinate(coordinate: CLLocationCoordinate2D) -> Bool! {
+        return contains(coordinate)
+    }
+    
+    /**
+     Returns a Boolean value indicating whether the bounding box contains the specified coordinate.
+     */
+    public func contains(coordinate: CLLocationCoordinate2D) -> Bool {
         return (coordinate.latitude >= southWest.latitude && coordinate.latitude <= northEast.latitude
             && coordinate.longitude >= southWest.longitude && coordinate.longitude <= northEast.longitude)
     }


### PR DESCRIPTION
This change renames `RectangularRegion.containsCoordinate(_:)` to `RectangularRegion.contains(_:)` to better adhere to [Swift API naming conventions](https://swift.org/documentation/api-design-guidelines/#strive-for-fluent-usage) and avoid the mess that is CLRegion’s deprecated methods (that have been moved to CLCircularRegion).

Fixes #51.