### PR TITLE
Pass through error messages

### DIFF
--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -235,7 +235,8 @@ public class Geocoder: NSObject {
                 }
             }
             
-            guard data != nil && error == nil else {
+            let apiMessage = json["message"] as? String
+            guard data != nil && error == nil && apiMessage == nil else {
                 let apiError = Geocoder.descriptiveError(json, response: response, underlyingError: error)
                 dispatch_async(dispatch_get_main_queue()) {
                     errorHandler(error: apiError)


### PR DESCRIPTION
When the API reports an input error, there will be data and no HTTP error, but we still need to send the completion handler an NSError.

/ref mapbox/MapboxDirections.swift@4ed92bf692e2ea120c972041d56e6ea92fda2d34