### PR TITLE
OS X → macOS

### DIFF
--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -23,7 +23,7 @@ let userAgent: String = {
     
     let system: String
     #if os(OSX)
-        system = "OS X"
+        system = "macOS"
     #elseif os(iOS)
         system = "iOS"
     #elseif os(watchOS)


### PR DESCRIPTION
For consistency with the Mapbox macOS SDK, the user agent string now says “macOS” instead of “OS X” on the Mac.

/cc @mick