### PR TITLE
Export both MBPlacemarkScope and PlacemarkScope

### DIFF
--- a/Geocoder Example/ViewController.m
+++ b/Geocoder Example/ViewController.m
@@ -55,6 +55,7 @@ NSString *const MapboxAccessToken = @"<# your Mapbox access token #>";
 - (void)mapView:(MGLMapView *)mapView regionDidChangeAnimated:(BOOL)animated {
     [self.geocodingDataTask cancel];
     MBReverseGeocodeOptions *options = [[MBReverseGeocodeOptions alloc] initWithCoordinate:self.mapView.centerCoordinate];
+    options.allowedScopes = MBPlacemarkScopeAll;
     [self.geocoder geocodeWithOptions:options completionHandler:^(NSArray<MBGeocodedPlacemark *> * _Nullable placemarks, NSString * _Nullable attribution, NSError * _Nullable error) {
         if (error) {
             NSLog(@"%@", error);

--- a/MapboxGeocoder/MBPlacemarkScope.h
+++ b/MapboxGeocoder/MBPlacemarkScope.h
@@ -27,4 +27,4 @@ typedef NS_OPTIONS(NSUInteger, MBPlacemarkScope) {
     
     /// All scopes.
     MBPlacemarkScopeAll = 0x0ffffUL,
-} NS_SWIFT_NAME(PlacemarkScope);
+};

--- a/MapboxGeocoder/MBPlacemarkScope.swift
+++ b/MapboxGeocoder/MBPlacemarkScope.swift
@@ -1,3 +1,5 @@
+public typealias PlacemarkScope = MBPlacemarkScope
+
 extension PlacemarkScope: CustomStringConvertible {
     /**
      Initializes a placemark scope bitmask corresponding to the given array of string representations of scopes.


### PR DESCRIPTION
`NS_SWIFT_NAME` doesn’t work very well on an enumeration inside a Swift framework.

Fixes #59, fixes #60.

/cc @incanus @friedbunny