### PR TITLE
Avoid deserializing non-JSON response data

### DIFF
--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -227,7 +227,7 @@ public class Geocoder: NSObject {
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         return NSURLSession.sharedSession().dataTaskWithRequest(request) { (data, response, error) in
             var json: JSONDictionary = [:]
-            if let data = data {
+            if let data = data where response?.MIMEType == "application/json" {
                 do {
                     json = try NSJSONSerialization.JSONObjectWithData(data, options: []) as! JSONDictionary
                 } catch {


### PR DESCRIPTION
Fixed an assertion failure that could occur (instead of an error being passed to the completion handler) if the response data was not the expected JSON format. This can happen, for instance, on a captive network.

For consistency with mapbox/MapboxDirections.swift#72, this PR avoids checking the response’s status code at this particular point.

/cc @willwhite