### PR TITLE
Accept application/vnd.geo+json MIME type

### DIFF
--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -227,7 +227,7 @@ public class Geocoder: NSObject {
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         return NSURLSession.sharedSession().dataTaskWithRequest(request) { (data, response, error) in
             var json: JSONDictionary = [:]
-            if let data = data where response?.MIMEType == "application/json" {
+            if let data = data, mimeType = response?.MIMEType where mimeType == "application/json" || mimeType == "application/vnd.geo+json" {
                 do {
                     json = try NSJSONSerialization.JSONObjectWithData(data, options: []) as! JSONDictionary
                 } catch {

--- a/MapboxGeocoderTests/ForwardGeocodingTests.swift
+++ b/MapboxGeocoderTests/ForwardGeocodingTests.swift
@@ -16,7 +16,7 @@ class ForwardGeocodingTests: XCTestCase {
             && isPath("/geocoding/v5/mapbox.places/1600+pennsylvania+ave.json")
             && containsQueryParams(["country": "ca", "access_token": BogusToken])) { _ in
             let path = NSBundle(forClass: self.dynamicType).pathForResource("forward_valid", ofType: "json")
-            return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
+            return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
         }
         
         let geocoder = Geocoder(accessToken: BogusToken)
@@ -70,7 +70,7 @@ class ForwardGeocodingTests: XCTestCase {
             && isPath("/geocoding/v5/mapbox.places/Sandy+Island,+New+Caledonia.json")
             && containsQueryParams(["country": "nc", "types": "region,place,locality,poi", "access_token": BogusToken])) { _ in
                 let path = NSBundle(forClass: self.dynamicType).pathForResource("forward_invalid", ofType: "json")
-                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
+                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
         }
         
         let expection = expectationWithDescription("forward geocode execute completion handler for invalid query")

--- a/MapboxGeocoderTests/ReverseGeocodingTests.swift
+++ b/MapboxGeocoderTests/ReverseGeocodingTests.swift
@@ -16,7 +16,7 @@ class ReverseGeocodingTests: XCTestCase {
             && isPath("/geocoding/v5/mapbox.places/-95.78558,37.13284.json")
             && containsQueryParams(["access_token": BogusToken])) { _ in
                 let path = NSBundle(forClass: self.dynamicType).pathForResource("reverse_valid", ofType: "json")
-                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
+                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
         }
 
         let geocoder = Geocoder(accessToken: BogusToken)
@@ -76,7 +76,7 @@ class ReverseGeocodingTests: XCTestCase {
             && isPath("/geocoding/v5/mapbox.places/0.00000,0.00000.json")
             && containsQueryParams(["access_token": BogusToken])) { _ in
                 let path = NSBundle(forClass: self.dynamicType).pathForResource("reverse_invalid", ofType: "json")
-                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
+                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
         }
         
         let expection = expectationWithDescription("reverse geocode execute completion handler for invalid query")


### PR DESCRIPTION
Fixed a regression introduced in #71, which assumed that parseable API responses always have the MIME type `application/json`. In fact, API responses always have the `application/vnd.geo+json` MIME type except for certain kinds of errors, like the one for an incorrect access token.

/cc @bsudekum @frederoni @willwhite