### PR TITLE
flesh out all test targets for both Objective-C & Swift

### DIFF
--- a/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/Example (Objective-C).xcscheme
+++ b/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/Example (Objective-C).xcscheme
@@ -28,6 +28,36 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DDF1E8491BD6F7BA00C40C78"
+               BuildableName = "MapboxGeocoderTests.xctest"
+               BlueprintName = "MapboxGeocoderTests"
+               ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA51709E1CF1B18F00CD6DCF"
+               BuildableName = "MapboxGeocoderTests.xctest"
+               BlueprintName = "MapboxGeocoderMacTests"
+               ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA5170C91CF253EE00CD6DCF"
+               BuildableName = "MapboxGeocoderTests.xctest"
+               BlueprintName = "MapboxGeocoderTVTests"
+               ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/Example (Swift).xcscheme
+++ b/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/Example (Swift).xcscheme
@@ -38,6 +38,26 @@
                ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA51709E1CF1B18F00CD6DCF"
+               BuildableName = "MapboxGeocoderTests.xctest"
+               BlueprintName = "MapboxGeocoderMacTests"
+               ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA5170C91CF253EE00CD6DCF"
+               BuildableName = "MapboxGeocoderTests.xctest"
+               BlueprintName = "MapboxGeocoderTVTests"
+               ReferencedContainer = "container:MapboxGeocoder.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference


### PR DESCRIPTION
We didn't have all test targets on the Swift scheme nor any on the Objective-C one. 