### PR TITLE
fix crash in allowedRegion use & add test

### DIFF
--- a/MapboxGeocoder/MBRectangularRegion.swift
+++ b/MapboxGeocoder/MBRectangularRegion.swift
@@ -47,6 +47,10 @@ public class RectangularRegion: CLRegion {
             && northEast.latitude == object.northEast.latitude && northEast.longitude == object.northEast.longitude)
     }
     
+    public override var description: String {
+        return "\(southWest.longitude),\(southWest.latitude),\(northEast.longitude),\(northEast.latitude)"
+    }
+
     /**
      Returns a Boolean value indicating whether the bounding box contains the specified coordinate.
      */

--- a/MapboxGeocoderTests/ForwardGeocodingTests.swift
+++ b/MapboxGeocoderTests/ForwardGeocodingTests.swift
@@ -23,6 +23,7 @@ class ForwardGeocodingTests: XCTestCase {
         var addressPlacemark: GeocodedPlacemark! = nil
         let options = ForwardGeocodeOptions(query: "1600 pennsylvania ave")
         options.allowedISOCountryCodes = ["CA"]
+        options.allowedRegion = RectangularRegion(southWest: CLLocationCoordinate2D(latitude: -85, longitude: -179), northEast: CLLocationCoordinate2D(latitude: 85, longitude: 179))
         let task = geocoder.geocode(options: options) { (placemarks, attribution, error) in
             XCTAssertEqual(placemarks?.count, 4, "forward geocode should have 4 results")
             addressPlacemark = placemarks![0]


### PR DESCRIPTION
This crashed because `RectangularRegion` didn't properly conform to `CustomStringConvertible` the way its superclass `CLRegion` does and thus couldn't be converted into the necessary URL parameters. 