### PR TITLE
Fix landmark roundtripping

### DIFF
--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		DA2E03F21CB0FE0200D1269A /* MBRectangularRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2E03F11CB0FE0200D1269A /* MBRectangularRegion.swift */; };
 		DA2EC05C1CED72E900D4BA5D /* MBPlacemarkScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2EC05B1CED72E900D4BA5D /* MBPlacemarkScope.swift */; };
 		DA2EC05E1CED732F00D4BA5D /* MBGeocodeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2EC05D1CED732F00D4BA5D /* MBGeocodeOptions.swift */; };
+		DA4D90071DD63AEC006EC71A /* PlacemarkScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4D90061DD63AEC006EC71A /* PlacemarkScopeTests.swift */; };
+		DA4D90081DD63AEC006EC71A /* PlacemarkScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4D90061DD63AEC006EC71A /* PlacemarkScopeTests.swift */; };
+		DA4D90091DD63AEC006EC71A /* PlacemarkScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4D90061DD63AEC006EC71A /* PlacemarkScopeTests.swift */; };
 		DA5170AD1CF1B1DB00CD6DCF /* MapboxGeocoder.h in Headers */ = {isa = PBXBuildFile; fileRef = DDC229581A36073B006BE405 /* MapboxGeocoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA5170AE1CF1B1E000CD6DCF /* MBGeocodeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2EC05D1CED732F00D4BA5D /* MBGeocodeOptions.swift */; };
 		DA5170AF1CF1B1E000CD6DCF /* MBGeocoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC229591A36073B006BE405 /* MBGeocoder.swift */; };
@@ -171,6 +174,7 @@
 		DA2E03F11CB0FE0200D1269A /* MBRectangularRegion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBRectangularRegion.swift; sourceTree = "<group>"; };
 		DA2EC05B1CED72E900D4BA5D /* MBPlacemarkScope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBPlacemarkScope.swift; sourceTree = "<group>"; };
 		DA2EC05D1CED732F00D4BA5D /* MBGeocodeOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBGeocodeOptions.swift; sourceTree = "<group>"; };
+		DA4D90061DD63AEC006EC71A /* PlacemarkScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlacemarkScopeTests.swift; sourceTree = "<group>"; };
 		DA5170961CF1B18F00CD6DCF /* MapboxGeocoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxGeocoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA51709F1CF1B18F00CD6DCF /* MapboxGeocoderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxGeocoderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA5170C11CF253EE00CD6DCF /* MapboxGeocoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxGeocoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -402,6 +406,7 @@
 				DA701C001CB1292C00B0E520 /* GeocoderTests.swift */,
 				DA210BAA1CB4BE73008088FD /* ForwardGeocodingTests.swift */,
 				DDF1E84C1BD6F7BA00C40C78 /* ReverseGeocodingTests.swift */,
+				DA4D90061DD63AEC006EC71A /* PlacemarkScopeTests.swift */,
 				DDF1E84E1BD6F7BA00C40C78 /* Info.plist */,
 				DDF1E8571BD700EB00C40C78 /* Fixtures */,
 			);
@@ -1043,6 +1048,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DA5170B61CF1B1EF00CD6DCF /* ReverseGeocodingTests.swift in Sources */,
+				DA4D90081DD63AEC006EC71A /* PlacemarkScopeTests.swift in Sources */,
 				DA5170B41CF1B1EF00CD6DCF /* GeocoderTests.swift in Sources */,
 				DA5170B51CF1B1EF00CD6DCF /* ForwardGeocodingTests.swift in Sources */,
 			);
@@ -1065,6 +1071,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DA5170E11CF2542800CD6DCF /* ReverseGeocodingTests.swift in Sources */,
+				DA4D90091DD63AEC006EC71A /* PlacemarkScopeTests.swift in Sources */,
 				DA5170DF1CF2542800CD6DCF /* GeocoderTests.swift in Sources */,
 				DA5170E01CF2542800CD6DCF /* ForwardGeocodingTests.swift in Sources */,
 			);
@@ -1118,6 +1125,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DDF1E84D1BD6F7BA00C40C78 /* ReverseGeocodingTests.swift in Sources */,
+				DA4D90071DD63AEC006EC71A /* PlacemarkScopeTests.swift in Sources */,
 				DA210BAB1CB4BE73008088FD /* ForwardGeocodingTests.swift in Sources */,
 				DA701C011CB1292C00B0E520 /* GeocoderTests.swift in Sources */,
 			);

--- a/MapboxGeocoder/MBPlacemark.swift
+++ b/MapboxGeocoder/MBPlacemark.swift
@@ -161,10 +161,9 @@ public class Placemark: NSObject, NSCopying, NSSecureCoding {
      The scope offers a general indication of the size or importance of the feature represented by the placemark – in other words, how local the feature is.
      */
     public var scope: PlacemarkScope {
-        let components = identifier.characters.split(".")
-        assert(components.count == 2)
-        let scopeCharacters = identifier.characters.split(".").first!
-        return PlacemarkScope(descriptions: [String(scopeCharacters)])
+        let components = identifier.componentsSeparatedByString(".")
+        assert(components.count > 0)
+        return PlacemarkScope(descriptions: [components.prefix(2).joinWithSeparator(".")]) ?? PlacemarkScope(descriptions: [components.first!]) ?? []
     }
     
     /**

--- a/MapboxGeocoder/MBPlacemarkScope.h
+++ b/MapboxGeocoder/MBPlacemarkScope.h
@@ -22,11 +22,12 @@ typedef NS_OPTIONS(NSUInteger, MBPlacemarkScope) {
     MBPlacemarkScopeNeighborhood = (1 << 7),
     /// A physical address, such as to a business or residence.
     MBPlacemarkScopeAddress = (1 << 8),
-    /// A point of interest, such as a business or school.
-    MBPlacemarkScopePointOfInterest = (1 << 9),
-    /// Subset of regular points of interest. Landmarks are particularly notable or long-lived features like parks, museums, and places of worship.
-    MBPlacemarkScopePointOfInterestLandmark = (1 << 10),
-
+    
+    /// A particularly notable or long-lived point of interest, such as a park, museum, or place of worship.
+    MBPlacemarkScopeLandmark = (1 << 91),
+    /// A point of interest, such as a business or store.
+    MBPlacemarkScopePointOfInterest = MBPlacemarkScopeLandmark | (1 << 9),
+    
     /// All scopes.
     MBPlacemarkScopeAll = 0x0ffffUL,
 };

--- a/MapboxGeocoder/MBPlacemarkScope.h
+++ b/MapboxGeocoder/MBPlacemarkScope.h
@@ -24,7 +24,7 @@ typedef NS_OPTIONS(NSUInteger, MBPlacemarkScope) {
     MBPlacemarkScopeAddress = (1 << 8),
     
     /// A particularly notable or long-lived point of interest, such as a park, museum, or place of worship.
-    MBPlacemarkScopeLandmark = (1 << 91),
+    MBPlacemarkScopeLandmark = (1 << 10),
     /// A point of interest, such as a business or store.
     MBPlacemarkScopePointOfInterest = MBPlacemarkScopeLandmark | (1 << 9),
     

--- a/MapboxGeocoder/MBPlacemarkScope.swift
+++ b/MapboxGeocoder/MBPlacemarkScope.swift
@@ -27,7 +27,7 @@ extension PlacemarkScope: CustomStringConvertible {
             case "poi":
                 scope.insert(.PointOfInterest)
             case "poi.landmark":
-                scope.insert(.PointOfInterestLandmark)
+                scope.insert(.Landmark)
             default:
                 break
             }
@@ -64,7 +64,7 @@ extension PlacemarkScope: CustomStringConvertible {
         if contains(PlacemarkScope.PointOfInterest) {
             descriptions.append("poi")
         }
-        if contains(PlacemarkScope.PointOfInterestLandmark) {
+        if contains(PlacemarkScope.Landmark) {
             descriptions.append("poi.landmark")
         }
         return descriptions.joinWithSeparator(",")

--- a/MapboxGeocoder/MBPlacemarkScope.swift
+++ b/MapboxGeocoder/MBPlacemarkScope.swift
@@ -62,11 +62,8 @@ extension PlacemarkScope: CustomStringConvertible {
         if contains(.Address) {
             descriptions.append("address")
         }
-        
         if contains(.Landmark) {
-            descriptions.append("poi.landmark")
-        } else if contains(.PointOfInterest) {
-            descriptions.append("poi")
+            descriptions.append(contains(.PointOfInterest) ? "poi" : "poi.landmark")
         }
         return descriptions.joinWithSeparator(",")
     }

--- a/MapboxGeocoder/MBPlacemarkScope.swift
+++ b/MapboxGeocoder/MBPlacemarkScope.swift
@@ -37,34 +37,34 @@ extension PlacemarkScope: CustomStringConvertible {
     
     public var description: String {
         var descriptions: [String] = []
-        if contains(PlacemarkScope.Country) {
+        if contains(.Country) {
             descriptions.append("country")
         }
-        if contains(PlacemarkScope.Region) {
+        if contains(.Region) {
             descriptions.append("region")
         }
-        if contains(PlacemarkScope.District) {
+        if contains(.District) {
             descriptions.append("district")
         }
-        if contains(PlacemarkScope.PostalCode) {
+        if contains(.PostalCode) {
             descriptions.append("postcode")
         }
-        if contains(PlacemarkScope.Place) {
+        if contains(.Place) {
             descriptions.append("place")
         }
-        if contains(PlacemarkScope.Locality) {
+        if contains(.Locality) {
             descriptions.append("locality")
         }
-        if contains(PlacemarkScope.Neighborhood) {
+        if contains(.Neighborhood) {
             descriptions.append("neighborhood")
         }
-        if contains(PlacemarkScope.Address) {
+        if contains(.Address) {
             descriptions.append("address")
         }
-        if contains(PlacemarkScope.PointOfInterest) {
+        if contains(.PointOfInterest) {
             descriptions.append("poi")
         }
-        if contains(PlacemarkScope.Landmark) {
+        if contains(.Landmark) {
             descriptions.append("poi.landmark")
         }
         return descriptions.joinWithSeparator(",")

--- a/MapboxGeocoder/MBPlacemarkScope.swift
+++ b/MapboxGeocoder/MBPlacemarkScope.swift
@@ -4,7 +4,7 @@ extension PlacemarkScope: CustomStringConvertible {
     /**
      Initializes a placemark scope bitmask corresponding to the given array of string representations of scopes.
      */
-    public init(descriptions: [String]) {
+    public init?(descriptions: [String]) {
         var scope: PlacemarkScope = []
         for description in descriptions {
             switch description {
@@ -24,12 +24,13 @@ extension PlacemarkScope: CustomStringConvertible {
                 scope.insert(.Neighborhood)
             case "address":
                 scope.insert(.Address)
-            case "poi":
-                scope.insert(.PointOfInterest)
+                
             case "poi.landmark":
                 scope.insert(.Landmark)
+            case "poi":
+                scope.insert(.PointOfInterest)
             default:
-                break
+                return nil
             }
         }
         self.init(rawValue: scope.rawValue)
@@ -61,11 +62,11 @@ extension PlacemarkScope: CustomStringConvertible {
         if contains(.Address) {
             descriptions.append("address")
         }
-        if contains(.PointOfInterest) {
-            descriptions.append("poi")
-        }
+        
         if contains(.Landmark) {
             descriptions.append("poi.landmark")
+        } else if contains(.PointOfInterest) {
+            descriptions.append("poi")
         }
         return descriptions.joinWithSeparator(",")
     }

--- a/MapboxGeocoderTests/ForwardGeocodingTests.swift
+++ b/MapboxGeocoderTests/ForwardGeocodingTests.swift
@@ -81,8 +81,8 @@ class ForwardGeocodingTests: XCTestCase {
         options.allowedScopes = [.Region, .Place, .Locality, .PointOfInterest]
         options.allowedISOCountryCodes = ["NC"]
         let task = geocoder.geocode(options: options) { (placemarks, attribution, error) in
-            XCTAssertNil(placemarks?.count, "forward geocode should return no results for invalid query")
-            XCTAssertNil(attribution)
+            XCTAssertEqual(placemarks?.count, 0, "forward geocode should return no results for invalid query")
+            XCTAssertEqual(attribution, "NOTICE: © 2016 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https://www.mapbox.com/about/maps/). This response and the information it contains may not be retained.")
             
             expection.fulfill()
         }

--- a/MapboxGeocoderTests/ForwardGeocodingTests.swift
+++ b/MapboxGeocoderTests/ForwardGeocodingTests.swift
@@ -81,9 +81,8 @@ class ForwardGeocodingTests: XCTestCase {
         options.allowedScopes = [.Region, .Place, .Locality, .PointOfInterest]
         options.allowedISOCountryCodes = ["NC"]
         let task = geocoder.geocode(options: options) { (placemarks, attribution, error) in
-            XCTAssertEqual(placemarks?.count, 0, "forward geocode should return no results for invalid query")
-            
-            XCTAssertEqual(attribution, "NOTICE: © 2016 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https://www.mapbox.com/about/maps/). This response and the information it contains may not be retained.")
+            XCTAssertNil(placemarks?.count, "forward geocode should return no results for invalid query")
+            XCTAssertNil(attribution)
             
             expection.fulfill()
         }

--- a/MapboxGeocoderTests/PlacemarkScopeTests.swift
+++ b/MapboxGeocoderTests/PlacemarkScopeTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import MapboxGeocoder
+
+class PlacemarkScopeTests: XCTestCase {
+    func testContainment() {
+        XCTAssert(PlacemarkScope.All.contains(.Country))
+        XCTAssert(PlacemarkScope.All.contains(.Region))
+        XCTAssert(PlacemarkScope.All.contains(.District))
+        XCTAssert(PlacemarkScope.All.contains(.PostalCode))
+        XCTAssert(PlacemarkScope.All.contains(.Place))
+        XCTAssert(PlacemarkScope.All.contains(.Locality))
+        XCTAssert(PlacemarkScope.All.contains(.Neighborhood))
+        XCTAssert(PlacemarkScope.All.contains(.Address))
+        XCTAssert(PlacemarkScope.PointOfInterest.contains(.Landmark))
+        XCTAssert(PlacemarkScope.All.contains(.PointOfInterest))
+        
+        XCTAssertEqual(PlacemarkScope.All.description.componentsSeparatedByString(",").count, 9, "testContainment() needs to be updated.")
+        
+        XCTAssertLessThanOrEqual(PlacemarkScope.All.rawValue, PlacemarkScope.RawValue.max)
+        XCTAssertLessThanOrEqual(PlacemarkScope(descriptions: PlacemarkScope.All.description.componentsSeparatedByString(","))?.rawValue ?? .max, PlacemarkScope.All.rawValue)
+    }
+    
+    func testDescriptions() {
+        XCTAssertNil(PlacemarkScope(descriptions: ["neighbourhood"]))
+        XCTAssertEqual(PlacemarkScope(descriptions: PlacemarkScope.All.description.componentsSeparatedByString(","))?.description, PlacemarkScope.All.description)
+        
+        XCTAssertEqual(PlacemarkScope(descriptions: ["poi"]), .PointOfInterest)
+        XCTAssertEqual(PlacemarkScope(descriptions: ["poi.landmark"]), .Landmark)
+        XCTAssertEqual(PlacemarkScope(descriptions: ["poi", "poi.landmark"]), .PointOfInterest)
+    }
+}


### PR DESCRIPTION
Fixed an issue causing landmark placemarks to have no scope. Also renamed and renumbered the `Landmark` scope. Now enabling points of interest automatically enables landmarks.

/cc @incanus