### PR TITLE
Fixed parsing of the rate limit error response

### DIFF
--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -308,7 +308,9 @@ open class Geocoder: NSObject {
             userInfo[NSLocalizedFailureReasonErrorKey] = failureReason ?? userInfo[NSLocalizedFailureReasonErrorKey] ?? HTTPURLResponse.localizedString(forStatusCode: error?.code ?? -1)
             userInfo[NSLocalizedRecoverySuggestionErrorKey] = recoverySuggestion ?? userInfo[NSLocalizedRecoverySuggestionErrorKey]
         }
-        userInfo[NSUnderlyingErrorKey] = error
+        if let error = error {
+            userInfo[NSUnderlyingErrorKey] = error
+        }
         return NSError(domain: error?.domain ?? MBGeocoderErrorDomain, code: error?.code ?? -1, userInfo: userInfo)
     }
 }

--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -294,7 +294,7 @@ open class Geocoder: NSObject {
                 if let timeInterval = response.rateLimitInterval, let maximumCountOfRequests = response.rateLimit {
                     let intervalFormatter = DateComponentsFormatter()
                     intervalFormatter.unitsStyle = .full
-                    let formattedInterval = intervalFormatter.string(from: timeInterval) ?? "? minutes"
+                    let formattedInterval = intervalFormatter.string(from: timeInterval) ?? "\(timeInterval) seconds"
                     let formattedCount = NumberFormatter.localizedString(from: maximumCountOfRequests as NSNumber, number: .decimal)
                     failureReason = "More than \(formattedCount) requests have been made with this access token within a period of \(formattedInterval)."
                 }

--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -338,7 +338,7 @@ extension HTTPURLResponse {
             return nil
         }
         guard let resetTimeNumber = Double(resetTime) else {
-            return nil;
+            return nil
         }
         return Date(timeIntervalSince1970: resetTimeNumber)
     }

--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -284,23 +284,22 @@ open class Geocoder: NSObject {
     /**
      Returns an error that supplements the given underlying error with additional information from the an HTTP response’s body or headers.
      */
-    fileprivate static func descriptiveError(_ json: JSONDictionary, response: URLResponse?, underlyingError error: NSError?) -> NSError {
+    static func descriptiveError(_ json: JSONDictionary, response: URLResponse?, underlyingError error: NSError?) -> NSError {
         var userInfo = error?.userInfo ?? [:]
         if let response = response as? HTTPURLResponse {
             var failureReason: String? = nil
             var recoverySuggestion: String? = nil
             switch response.statusCode {
             case 429:
-                if let timeInterval = response.allHeaderFields["x-rate-limit-interval"] as? TimeInterval, let maximumCountOfRequests = response.allHeaderFields["x-rate-limit-limit"] as? UInt {
+                if let timeInterval = response.rateLimitInterval, let maximumCountOfRequests = response.rateLimit {
                     let intervalFormatter = DateComponentsFormatter()
                     intervalFormatter.unitsStyle = .full
-                    let formattedInterval = intervalFormatter.string(from: timeInterval)
+                    let formattedInterval = intervalFormatter.string(from: timeInterval) ?? "? minutes"
                     let formattedCount = NumberFormatter.localizedString(from: maximumCountOfRequests as NSNumber, number: .decimal)
                     failureReason = "More than \(formattedCount) requests have been made with this access token within a period of \(formattedInterval)."
                 }
-                if let rolloverTimestamp = response.allHeaderFields["x-rate-limit-reset"] as? Double {
-                    let date = Date(timeIntervalSince1970: rolloverTimestamp)
-                    let formattedDate = DateFormatter.localizedString(from: date, dateStyle: .long, timeStyle: .full)
+                if let rolloverTime = response.rateLimitResetTime {
+                    let formattedDate = DateFormatter.localizedString(from: rolloverTime, dateStyle: .long, timeStyle: .full)
                     recoverySuggestion = "Wait until \(formattedDate) before retrying."
                 }
             default:
@@ -312,4 +311,36 @@ open class Geocoder: NSObject {
         userInfo[NSUnderlyingErrorKey] = error
         return NSError(domain: error?.domain ?? MBGeocoderErrorDomain, code: error?.code ?? -1, userInfo: userInfo)
     }
+}
+
+extension HTTPURLResponse {
+    
+    static let rateLimitIntervalHeaderKey = "X-Rate-Limit-Interval"
+    static let rateLimitLimitHeaderKey = "X-Rate-Limit-Limit"
+    static let rateLimitResetHeaderKey = "X-Rate-Limit-Reset"
+    
+    var rateLimit: UInt? {
+        guard let limit = allHeaderFields[HTTPURLResponse.rateLimitLimitHeaderKey] as? String else {
+            return nil
+        }
+        return UInt(limit)
+    }
+    
+    var rateLimitInterval: TimeInterval? {
+        guard let interval = allHeaderFields[HTTPURLResponse.rateLimitIntervalHeaderKey] as? String else {
+            return nil
+        }
+        return TimeInterval(interval)
+    }
+    
+    var rateLimitResetTime: Date? {
+        guard let resetTime = allHeaderFields[HTTPURLResponse.rateLimitResetHeaderKey] as? String else {
+            return nil
+        }
+        guard let resetTimeNumber = Double(resetTime) else {
+            return nil;
+        }
+        return Date(timeIntervalSince1970: resetTimeNumber)
+    }
+
 }

--- a/MapboxGeocoderTests/GeocoderTests.swift
+++ b/MapboxGeocoderTests/GeocoderTests.swift
@@ -5,6 +5,12 @@ import OHHTTPStubs
 let BogusToken = "pk.feedCafeDadeDeadBeef-BadeBede.FadeCafeDadeDeed-BadeBede"
 
 class GeocoderTests: XCTestCase {
+    
+    override func setUp() {
+        // Make sure tests run in all time zones
+        NSTimeZone.default = TimeZone(secondsFromGMT: 0)!
+    }
+    
     override func tearDown() {
         OHHTTPStubs.removeAllStubs()
         super.tearDown()
@@ -14,5 +20,20 @@ class GeocoderTests: XCTestCase {
         let geocoder = Geocoder(accessToken: BogusToken)
         XCTAssertEqual(geocoder.accessToken, BogusToken)
         XCTAssertEqual(geocoder.apiEndpoint.absoluteString, "https://api.mapbox.com")
+    }
+    
+    func testRateLimitErrorParsing() {
+        let json = ["message" : "Hit rate limit"]
+        
+        let url = URL(string: "https://api.mapbox.com")!
+        let headerFields = ["X-Rate-Limit-Interval" : "60", "X-Rate-Limit-Limit" : "600", "X-Rate-Limit-Reset" : "1479460584"]
+        let response = HTTPURLResponse(url: url, statusCode: 429, httpVersion: nil, headerFields: headerFields)
+        
+        let error: NSError? = nil
+        
+        let resultError = Geocoder.descriptiveError(json, response: response, underlyingError: error)
+        
+        XCTAssertEqual(resultError.localizedFailureReason, "More than 600 requests have been made with this access token within a period of 1 minute.")
+        XCTAssertEqual(resultError.localizedRecoverySuggestion, "Wait until November 18, 2016 at 9:16:24 AM GMT before retrying.")
     }
 }


### PR DESCRIPTION
This is not a fix for #90. Wasn't able to reproduce it so far — maybe something related to the Swift optimisation.

However, the parsing of the header fields in a case of the rate limit being hit had multiple problems:
* Use of lowercase header names. The header in the server response are uppercase (`x-rate-limit-interval` vs `X-Rate-Limit-Interval`)
* It was expected that the `allHeaderFields` dict contains values in the respective data type. However, the dict just contains the values as strings.

This PR
* fixes the mentioned problems
* exposes the `descriptiveError` function in the module (not public) for making it testable
* adds a test to verify the behaviour