### PR TITLE
Xcode 8.2, CocoaPods 1.2

### DIFF
--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -656,7 +656,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = Mapbox;
 				TargetAttributes = {
 					DA5170951CF1B18F00CD6DCF = {
@@ -1354,6 +1354,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				CURRENT_PROJECT_VERSION = 3;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -1381,6 +1382,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 3;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -1226,7 +1226,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = AAD436380AAB501AB6291304 /* Pods-MapboxGeocoderMacTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1319,7 +1318,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BF3AEBC5904F365B64817732 /* Pods-MapboxGeocoderTVTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1610,7 +1608,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 05A6B8764F1B74BB857B037B /* Pods-MapboxGeocoderTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = MapboxGeocoderTests/Info.plist;

--- a/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/Example (Objective-C).xcscheme
+++ b/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/Example (Objective-C).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/MapboxGeocoder iOS.xcscheme
+++ b/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/MapboxGeocoder iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/MapboxGeocoder tvOS.xcscheme
+++ b/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/MapboxGeocoder tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/MapboxGeocoder watchOS.xcscheme
+++ b/MapboxGeocoder.xcodeproj/xcshareddata/xcschemes/MapboxGeocoder watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 use_frameworks!
 
 def shared_pods
-  pod 'Mapbox-iOS-SDK', '~> 3.3'
+  pod 'Mapbox-iOS-SDK', '~> 3.4'
 end
 
 def shared_test_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
-  - Mapbox-iOS-SDK (3.3.6)
-  - OHHTTPStubs/Core (5.2.2)
-  - OHHTTPStubs/Swift (5.2.2):
+  - Mapbox-iOS-SDK (3.4.1)
+  - OHHTTPStubs/Core (5.2.3)
+  - OHHTTPStubs/Swift (5.2.3):
     - OHHTTPStubs/Core
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK (~> 3.3)
+  - Mapbox-iOS-SDK (~> 3.4)
   - OHHTTPStubs/Swift (~> 5.0)
 
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: 1651ab31beec917b60ccbb8f737d0435ec80eeb3
-  OHHTTPStubs: 34d9d0994e64fcf8552dbfade5ce82ada913ee31
+  Mapbox-iOS-SDK: 9c0d23e9a3784e6c9e45af4339898e4598b5b09b
+  OHHTTPStubs: e238cd5b66d8efa51c861db45895de8fe079f4a7
 
-PODFILE CHECKSUM: 0d327e0fe430b4211f61e91065c69151ac64aef7
+PODFILE CHECKSUM: c226b6f83d5572c7669bfdd75dd6622a2e1a5fa0
 
-COCOAPODS: 1.1.1
+COCOAPODS: 1.2.0


### PR DESCRIPTION
Upgraded to Xcode 8.2, CocoaPods 1.2, iOS SDK v3.4.1, and OHHTTPStubs v5.2.3. Fixed CocoaPods warnings about `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` being overridden.

/cc @friedbunny