### PR TITLE
Refine shared property, geocode methods

### DIFF
--- a/Geocoder Example/ViewController.m
+++ b/Geocoder Example/ViewController.m
@@ -56,7 +56,7 @@ NSString *const MapboxAccessToken = @"<# your Mapbox access token #>";
     [self.geocodingDataTask cancel];
     MBReverseGeocodeOptions *options = [[MBReverseGeocodeOptions alloc] initWithCoordinate:self.mapView.centerCoordinate];
     options.allowedScopes = MBPlacemarkScopeAll;
-    [self.geocoder geocode:options completionHandler:^(NSArray<MBGeocodedPlacemark *> * _Nullable placemarks, NSString * _Nullable attribution, NSError * _Nullable error) {
+    [self.geocoder geocodeWithOptions:options completionHandler:^(NSArray<MBGeocodedPlacemark *> * _Nullable placemarks, NSString * _Nullable attribution, NSError * _Nullable error) {
         if (error) {
             NSLog(@"%@", error);
         } else if (placemarks.count > 0) {

--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -170,6 +170,7 @@ open class Geocoder: NSObject {
      - parameter completionHandler: The closure (block) to call with the resulting placemarks. This closure is executed on the application’s main thread.
      - returns: The data task used to perform the HTTP request. If, while waiting for the completion handler to execute, you no longer want the resulting placemarks, cancel this task.
      */
+    @objc(geocodeWithOptions:completionHandler:)
     open func geocode(_ options: GeocodeOptions, completionHandler: @escaping CompletionHandler) -> URLSessionDataTask {
         let url = urlForGeocoding(options)
         let task = dataTaskWithURL(url, completionHandler: { (json) in

--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -119,7 +119,8 @@ open class Geocoder: NSObject {
      
      To use this object, a Mapbox [access token](https://www.mapbox.com/help/define-access-token/) should be specified in the `MGLMapboxAccessToken` key in the main application bundle’s Info.plist.
      */
-    open static let sharedGeocoder = Geocoder(accessToken: nil)
+    @objc(sharedGeocoder)
+    open static let shared = Geocoder(accessToken: nil)
     
     /// The API endpoint to request the geocodes from.
     internal var apiEndpoint: URL

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ options.allowedISOCountryCodes = @[@"CA"];
 options.focalLocation = [[CLLocation alloc] initWithLatitude:45.3 longitude:-66.1];
 options.allowedScopes = MBPlacemarkScopeAddress | MBPlacemarkScopePointOfInterest;
 
-NSURLSessionDataTask *task = [geocoder geocode:options
-                             completionHandler:^(NSArray<MBGeocodedPlacemark *> * _Nullable placemarks,
-                                                 NSString * _Nullable attribution,
-                                                 NSError * _Nullable error) {
+NSURLSessionDataTask *task = [geocoder geocodeWithOptions:options
+                                        completionHandler:^(NSArray<MBGeocodedPlacemark *> * _Nullable placemarks,
+                                                            NSString * _Nullable attribution,
+                                                            NSError * _Nullable error) {
     MBPlacemark *placemark = placemarks[0];
     NSLog(@"%@", placemark.name);
         // 200 Queen St
@@ -175,10 +175,10 @@ let task = geocoder.geocode(options) { (placemarks, attribution, error) in
 MBReverseGeocodeOptions *options = [[MBReverseGeocodeOptions alloc] initWithCoordinate: CLLocationCoordinate2DMake(40.733, -73.989)];
 // Or perhaps: [[MBReverseGeocodeOptions alloc] initWithLocation:locationManager.location]
 
-NSURLSessionDataTask *task = [geocoder geocode:options
-                             completionHandler:^(NSArray<MBGeocodedPlacemark *> * _Nullable placemarks,
-                                                 NSString * _Nullable attribution,
-                                                 NSError * _Nullable error) {
+NSURLSessionDataTask *task = [geocoder geocodeWithOptions:options
+                                        completionHandler:^(NSArray<MBGeocodedPlacemark *> * _Nullable placemarks,
+                                                            NSString * _Nullable attribution,
+                                                            NSError * _Nullable error) {
     MBPlacemark *placemark = placemarks[0];
     NSLog(@"%@", placemark.imageName);
         // telephone

--- a/README.md
+++ b/README.md
@@ -218,24 +218,6 @@ let task = geocoder.batchGeocode(options) { (placemarksByQuery, attributionsByQu
 }
 ```
 
-```objc
-// main.m
-MBForwardBatchGeocodeOptions *options = [[MBForwardBatchGeocodeOptions alloc] initWithQueries:@[@"skyline chili", @"gold star chili"]];
-options.focalLocation = locationManager.location;
-options.allowedScopes = MBPlacemarkScopePointOfInterest;
-
-NSURLSessionDataTask *task = [geocoder batchGeocode:options completionHandler:^(NSArray<NSArray<MBGeocodedPlacemark *> *> * _Nullable placemarksByQuery, NSArray<NSString *> * _Nullable attributionsByQuery, NSError * _Nullable error) {
-    MBPlacemark *nearestSkyline = placemarksByQuery[0][0].location;
-    CLLocationDistance distanceToSkyline = [nearestSkyline distanceFromLocation:locationManager.location];
-    MBPlacemark *nearestGoldStar = placemarksByQuery[1][0].location;
-    CLLocationDistance distanceToGoldStar = [nearestGoldStar distanceFromLocation:locationManager.location];
-
-    NSLengthFormatter *formatter = [[NSLengthFormatter alloc] init];
-    NSString *distance = [formatter stringFromMeters:MIN(distanceToSkyline, distanceToGoldStar)];
-    NSLog("Found a chili parlor %@ away.", distance);
-}];
-```
-
 Batch geocoding is available to Mapbox enterprise accounts. See the [Mapbox Geocoding](https://www.mapbox.com/geocoding/) website for more information.
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Alternatively, you can place your access token in the `MGLMapboxAccessToken` key
 
 ```swift
 // main.swift
-let geocoder = Geocoder.sharedGeocoder
+let geocoder = Geocoder.shared
 ```
 
 ```objc


### PR DESCRIPTION
Also remvoed the batch geocoding example in Objective-C, since that method uses generics and therefore doesn’t bridge to Objective-C.

/cc @friedbunny