### PR TITLE
Fix Swift 3.1 compatibility

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 3.4
-github "AliSoftware/OHHTTPStubs" "swift-3.0"
+github "AliSoftware/OHHTTPStubs" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.4.2"
-github "AliSoftware/OHHTTPStubs" "57feceaabf333e72b2c637dfba6c13a7a5c49619"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.5.0"
+github "AliSoftware/OHHTTPStubs" "8660a5a2253bdd6291be36251ba90b06bceb46a2"

--- a/MapboxGeocoderTests/ForwardGeocodingTests.swift
+++ b/MapboxGeocoderTests/ForwardGeocodingTests.swift
@@ -35,7 +35,7 @@ class ForwardGeocodingTests: XCTestCase {
         XCTAssertNotNil(task)
         
         waitForExpectations(timeout: 1) { (error) in
-            XCTAssertNil(error, "Error: \(error)")
+            XCTAssertNil(error, "Error: \(error!)")
             XCTAssertEqual(task.state, URLSessionTask.State.completed)
         }
         
@@ -89,7 +89,7 @@ class ForwardGeocodingTests: XCTestCase {
         XCTAssertNotNil(task)
         
         waitForExpectations(timeout: 1) { (error) in
-            XCTAssertNil(error, "Error: \(error)")
+            XCTAssertNil(error, "Error: \(error!)")
             XCTAssertEqual(task.state, URLSessionTask.State.completed)
         }
     }
@@ -120,7 +120,7 @@ class ForwardGeocodingTests: XCTestCase {
         XCTAssertNotNil(task)
         
         waitForExpectations(timeout: 1) { (error) in
-            XCTAssertNil(error, "Error: \(error)")
+            XCTAssertNil(error, "Error: \(error!)")
             XCTAssertEqual(task.state, .completed)
         }
         

--- a/MapboxGeocoderTests/ReverseGeocodingTests.swift
+++ b/MapboxGeocoderTests/ReverseGeocodingTests.swift
@@ -35,7 +35,7 @@ class ReverseGeocodingTests: XCTestCase {
         XCTAssertNotNil(task)
 
         waitForExpectations(timeout: 1) { (error) in
-            XCTAssertNil(error, "Error: \(error)")
+            XCTAssertNil(error, "Error: \(error!)")
             XCTAssertEqual(task.state, URLSessionTask.State.completed)
         }
         
@@ -93,7 +93,7 @@ class ReverseGeocodingTests: XCTestCase {
         XCTAssertNotNil(task)
 
         waitForExpectations(timeout: 1) { (error) in
-            XCTAssertNil(error, "Error: \(error)")
+            XCTAssertNil(error, "Error: \(error!)")
             XCTAssertEqual(task.state, URLSessionTask.State.completed)
         }
     }


### PR DESCRIPTION
Resolved some Swift 3.1 compiler warnings in unit test code. Some optionals should’ve been force-unwrapped because they’d only be used if the optional turned out to be `nil`.

Also updated dependencies.

/cc @bsudekum