### PR TITLE
Inline HTTPURLResponse extension constants

### DIFF
--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -318,27 +318,22 @@ open class Geocoder: NSObject {
 }
 
 extension HTTPURLResponse {
-    
-    static let rateLimitIntervalHeaderKey = "X-Rate-Limit-Interval"
-    static let rateLimitLimitHeaderKey = "X-Rate-Limit-Limit"
-    static let rateLimitResetHeaderKey = "X-Rate-Limit-Reset"
-    
     var rateLimit: UInt? {
-        guard let limit = allHeaderFields[HTTPURLResponse.rateLimitLimitHeaderKey] as? String else {
+        guard let limit = allHeaderFields["X-Rate-Limit-Limit"] as? String else {
             return nil
         }
         return UInt(limit)
     }
     
     var rateLimitInterval: TimeInterval? {
-        guard let interval = allHeaderFields[HTTPURLResponse.rateLimitIntervalHeaderKey] as? String else {
+        guard let interval = allHeaderFields["X-Rate-Limit-Interval"] as? String else {
             return nil
         }
         return TimeInterval(interval)
     }
     
     var rateLimitResetTime: Date? {
-        guard let resetTime = allHeaderFields[HTTPURLResponse.rateLimitResetHeaderKey] as? String else {
+        guard let resetTime = allHeaderFields["X-Rate-Limit-Reset"] as? String else {
             return nil
         }
         guard let resetTimeNumber = Double(resetTime) else {


### PR DESCRIPTION
Inlined HTTPURLResponse extension constants, which were only being used in one place each and would be unlikely to change. These static constants were being bridged to Objective-C as class properties on categories, but they were triggering linker warnings about “incompatible Objective-C category definitions” in object files when bridged to Objective-C.

/cc @frederoni