### PR TITLE
Fix Obj-C example by forcing it to include Swift frameworks

### DIFF
--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -1398,6 +1398,7 @@
 		DDC2474819A1C60E0054B0C0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1416,6 +1417,7 @@
 		DDC2474919A1C60E0054B0C0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ pod 'MapboxGeocoder.swift', '~> 0.6'
 
 Then `import MapboxGeocoder` or `@import MapboxGeocoder;`.
 
+For Objective-C targets, it may be necessary to enable the `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` build setting.
+
 v0.5.2 is the last release of MapboxGeocoder.swift written in Swift 2.3. The `swift2.3` branch corresponds to this release, plus any critical bug fixes that have been applied since. All subsequent releases will be based on the `master` branch, which is written in Swift 3. The Swift examples below are written in Swift 3; see the `swift2.3` branch’s readme for Swift 2.3 examples.
 
 This repository includes example applications written in both Swift and Objective-C showing use of the framework (as well as a comparison of writing apps in either language). More examples and detailed documentation are available in the [Mapbox API Documentation](https://www.mapbox.com/api-documentation/?language=Swift#geocoding).


### PR DESCRIPTION
The Objective-C example was failing to load the Swift version of the Contacts framework, as required by MapboxGeocoder. Follows up on https://github.com/mapbox/MapboxGeocoder.swift/pull/83.

```
dyld: Library not loaded: @rpath/libswiftContacts.dylib
  Referenced from: /Library/Developer/Xcode/DerivedData/MapboxGeocoder-forgxhxxjpxndqethmnohkbagfeq/Build/Products/Debug-iphonesimulator/MapboxGeocoder.framework/MapboxGeocoder
  Reason: image not found
```

If an Obj-C application fails like this, add `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES` to the build settings for that target.

/cc @ericdeveloper @1ec5