### PR TITLE
Document the upper limits of MBGeocodeOptions.maximumResultCount

### DIFF
--- a/MapboxGeocoder/MBGeocodeOptions.swift
+++ b/MapboxGeocoder/MBGeocodeOptions.swift
@@ -47,7 +47,7 @@ open class GeocodeOptions: NSObject {
     open var allowedRegion: RectangularRegion?
     
     /**
-     Limit the number of results returned. The default is `5` for forward geocoding and `1` for reverse geocoding.
+     Limit the number of results returned. For forward geocoding, the default is `5` and the maximum is `10`. For reverse geocoding, the default is `1` and the maximum is `5`.
      */
     public var maximumResultCount: UInt
 


### PR DESCRIPTION
Essentially copies the [API docs](https://www.mapbox.com/api-documentation/#request-format) for the `limit` parameter, clarifying what the upper limits are for `MBGeocodeOptions.maximumResultCount`.

Prompted by [this SO question](https://stackoverflow.com/q/46810774/2094275).

/cc @1ec5 