### PR TITLE
Fix formatted address

### DIFF
--- a/MapboxGeocoder/MBPlacemark.swift
+++ b/MapboxGeocoder/MBPlacemark.swift
@@ -402,23 +402,19 @@ open class GeocodedPlacemark: Placemark {
         return (superiorPlacemarks?.map { $0.name } ?? []).reversed() + [name]
     }
     
-    @objc open override var name: String {
-        get {
-            let text = super.name
-            // For address features, `text` is just the street name. Look through the fully-qualified address to determine whether to put the house number before or after the street name.
-            if let houseNumber = address, scope == .address {
-                let streetName = text
-                let reversedAddress = "\(streetName) \(houseNumber)"
-                if qualifiedNameComponents.contains(reversedAddress) {
-                    return reversedAddress
-                } else {
-                    return "\(houseNumber) \(streetName)"
-                }
+    @objc open var formattedName: String {
+        let text = super.name
+        // For address features, `text` is just the street name. Look through the fully-qualified address to determine whether to put the house number before or after the street name.
+        if let houseNumber = address, scope == .address {
+            let streetName = text
+            let reversedAddress = "\(streetName) \(houseNumber)"
+            if qualifiedNameComponents.contains(reversedAddress) {
+                return reversedAddress
             } else {
-                return text
+                return "\(houseNumber) \(streetName)"
             }
-        } set {
-            super.name = name
+        } else {
+            return text
         }
     }
     

--- a/MapboxGeocoderTests/ReverseGeocodingTests.swift
+++ b/MapboxGeocoderTests/ReverseGeocodingTests.swift
@@ -112,7 +112,7 @@ class ReverseGeocodingTests: XCTestCase {
         }
         
         let geocoder = Geocoder(accessToken: BogusToken)
-        var addressPlacemark: Placemark?
+        var addressPlacemark: GeocodedPlacemark?
         let options = ReverseGeocodeOptions(location: CLLocation(latitude: 37.13284000, longitude: -95.78558000))
         let task = geocoder.geocode(options) { (placemarks, attribution, error) in
             addressPlacemark = placemarks?.first
@@ -125,6 +125,12 @@ class ReverseGeocodingTests: XCTestCase {
         }
         
         XCTAssertNotNil(task)
-        XCTAssert(addressPlacemark?.name == "850 Eldorado Street", "Address not parsed correctly")
+        XCTAssert(addressPlacemark?.formattedName == "850 Eldorado Street", "Address not parsed correctly")
+        
+        let encodedData = try! JSONEncoder().encode(addressPlacemark!)
+        let decodedAddressPlacemark = try! JSONDecoder().decode(GeocodedPlacemark.self, from: encodedData)
+        
+        XCTAssertEqual(addressPlacemark?.name, decodedAddressPlacemark.name)
+        XCTAssertEqual(addressPlacemark?.formattedName, decodedAddressPlacemark.formattedName)
     }
 }


### PR DESCRIPTION
Previously, when a `GeocodedPlacemark` was encoded, the computed getter, which in this case contained a house number, would get appended to the name property and be decoded as a formatted address. Next time `name` was accessed, it applied the same format when the house number was already there so it did not round-trip through encoding→decoding properly.

@bsudekum @1ec5 👀 