### PR TITLE
Add routable points option and parse results

### DIFF
--- a/MapboxGeocoder/MBGeocodeOptions.swift
+++ b/MapboxGeocoder/MBGeocodeOptions.swift
@@ -66,9 +66,9 @@ open class GeocodeOptions: NSObject {
     
     
     /**
-     If true, the response will possibly include a `routeableLocation`.
+     If true, the response will possibly include a `routableLocation`.
      
-     `routeableLocation` represents the best location for a vehicle to navigate to.
+     `routableLocation` represents the best location for a vehicle to navigate to.
      */
     @objc open var includeRoutableLocations: Bool = false
     

--- a/MapboxGeocoder/MBGeocodeOptions.swift
+++ b/MapboxGeocoder/MBGeocodeOptions.swift
@@ -64,6 +64,14 @@ open class GeocodeOptions: NSObject {
      */
     @objc open var locale: Locale?
     
+    
+    /**
+     If true, the response will possibly include a `routeableLocation`.
+     
+     `routeableLocation` represents the best location for a vehicle to navigate to.
+     */
+    @objc open var includeRoutableLocations: Bool = false
+    
     fileprivate override init() {
         self.maximumResultCount = 0
         super.init()
@@ -101,6 +109,9 @@ open class GeocodeOptions: NSObject {
         if let languageCode = (locale as NSLocale?)?.object(forKey: .languageCode) as? String {
             params.append(URLQueryItem(name: "language", value: languageCode))
         }
+        
+        params.append(URLQueryItem(name: "routing", value: String(describing: includeRoutableLocations)))
+        
         return params
     }
 }

--- a/MapboxGeocoder/MBPlacemark.swift
+++ b/MapboxGeocoder/MBPlacemark.swift
@@ -118,7 +118,7 @@ open class Placemark: NSObject, Codable {
         if let points = try? container.nestedContainer(keyedBy: RoutableLocationsKeys.self, forKey: .routableLocations),
             let coordinatePairs = try points.decodeIfPresent([[CLLocationDegrees]].self, forKey: .points) {
             let coordinates = coordinatePairs.map { CLLocationCoordinate2D(geoJSON: $0) }
-            routeableLocations = coordinates
+            routableLocations = coordinates
         }
     }
 
@@ -368,7 +368,7 @@ open class Placemark: NSObject, Codable {
     /**
      An array of locations representing the location a user should navigate to to reach the `Placemark`.
      */
-    @objc open var routeableLocations: [CLLocationCoordinate2D]?
+    @objc open var routableLocations: [CLLocationCoordinate2D]?
 }
 
 internal struct GeocodeResult: Codable {

--- a/MapboxGeocoder/MBPlacemark.swift
+++ b/MapboxGeocoder/MBPlacemark.swift
@@ -76,7 +76,13 @@ open class Placemark: NSObject, Codable {
         case wikidataItemIdentifier = "wikidata"
         case properties
         case boundingBox = "bbox"
+        case routableLocations = "routable_points"
     }
+    
+    private enum RoutableLocationsKeys: String, CodingKey {
+        case points = "points"
+    }
+    
     
     /**
      Creates a placemark from the given [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) feature.
@@ -107,6 +113,12 @@ open class Placemark: NSObject, Codable {
             let southWest = CLLocationCoordinate2D(geoJSON: Array(boundingBox.prefix(2)))
             let northEast = CLLocationCoordinate2D(geoJSON: Array(boundingBox.suffix(2)))
             region = RectangularRegion(southWest: southWest, northEast: northEast)
+        }
+        
+        if let points = try? container.nestedContainer(keyedBy: RoutableLocationsKeys.self, forKey: .routableLocations),
+            let coordinatePairs = try points.decodeIfPresent([[CLLocationDegrees]].self, forKey: .points) {
+            let coordinates = coordinatePairs.map { CLLocationCoordinate2D(geoJSON: $0) }
+            routeableLocations = coordinates
         }
     }
 
@@ -352,6 +364,11 @@ open class Placemark: NSObject, Codable {
         }
         return String(describing: houseNumber)
     }
+    
+    /**
+     An array of locations representing the location a user should navigate to to reach the `Placemark`.
+     */
+    @objc open var routeableLocations: [CLLocationCoordinate2D]?
 }
 
 internal struct GeocodeResult: Codable {


### PR DESCRIPTION
Closes: https://github.com/mapbox/MapboxGeocoder.swift/issues/144

Adds the option to get routable points back in the response and also an option to request routable points.

Currently, the response will look like:

```
 routable_points: {
    points: [{ coordinates: [lon, lat] }]
}
```

Paging codable experts @JThramer @frederoni, I'm slightly unsure if this is the preferred method for parsing optional + nested dictionaries. 