### PR TITLE
Fix batch geocoding request handling

### DIFF
--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -7,9 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		079F41E420E42D7F007EEB5E /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 079F41E320E42D7F007EEB5E /* permanent_forward_single_valid.json */; };
-		079F41E520E42D7F007EEB5E /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 079F41E320E42D7F007EEB5E /* permanent_forward_single_valid.json */; };
-		079F41E620E42D7F007EEB5E /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 079F41E320E42D7F007EEB5E /* permanent_forward_single_valid.json */; };
+		0711239320E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */; };
+		0711239420E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */; };
+		0711239520E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */; };
+		0711239F20E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */; };
+		071123A020E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */; };
+		071123A120E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */; };
 		079F41E820E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
 		079F41E920E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
 		079F41EA20E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
@@ -176,7 +179,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		079F41E320E42D7F007EEB5E /* permanent_forward_single_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_single_valid.json; path = ../../../../Desktop/permanent_forward_single_valid.json; sourceTree = "<group>"; };
+		0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_single_valid.json; path = ../../../../.Trash/permanent_forward_single_valid.json; sourceTree = "<group>"; };
+		0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_multiple_valid.json; path = ../../../../Desktop/permanent_forward_multiple_valid.json; sourceTree = "<group>"; };
 		079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchForwardGeocodingTests.swift; sourceTree = "<group>"; };
 		35506B8A200F856400629509 /* BridgingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BridgingTests.m; sourceTree = "<group>"; };
 		357B4357202CC90A00735521 /* reverse_address.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reverse_address.json; sourceTree = "<group>"; };
@@ -425,7 +429,8 @@
 		DDF1E8571BD700EB00C40C78 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
-				079F41E320E42D7F007EEB5E /* permanent_forward_single_valid.json */,
+				0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */,
+				0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */,
 				DA210BAC1CB4BFF7008088FD /* forward_valid.json */,
 				DA58D8A01DB2ADDD00530CBB /* forward_valid_zh.json */,
 				DA210BAE1CB4C5A7008088FD /* forward_invalid.json */,
@@ -741,7 +746,8 @@
 				DA5170B91CF1B1F900CD6DCF /* forward_invalid.json in Resources */,
 				DA5170BB1CF1B1F900CD6DCF /* reverse_invalid.json in Resources */,
 				DA5170BA1CF1B1F900CD6DCF /* reverse_valid.json in Resources */,
-				079F41E520E42D7F007EEB5E /* permanent_forward_single_valid.json in Resources */,
+				071123A020E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */,
+				0711239420E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A21DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -762,7 +768,8 @@
 				DA5170E31CF2542B00CD6DCF /* forward_invalid.json in Resources */,
 				DA5170E51CF2542B00CD6DCF /* reverse_invalid.json in Resources */,
 				DA5170E41CF2542B00CD6DCF /* reverse_valid.json in Resources */,
-				079F41E620E42D7F007EEB5E /* permanent_forward_single_valid.json in Resources */,
+				071123A120E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */,
+				0711239520E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A31DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -806,7 +813,8 @@
 				DDF1E85C1BD70E4C00C40C78 /* reverse_invalid.json in Resources */,
 				DDF1E85D1BD70E4C00C40C78 /* reverse_valid.json in Resources */,
 				DA210BAF1CB4C5A7008088FD /* forward_invalid.json in Resources */,
-				079F41E420E42D7F007EEB5E /* permanent_forward_single_valid.json in Resources */,
+				0711239F20E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */,
+				0711239320E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A11DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -19,9 +19,18 @@
 		071123A720E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */; };
 		071123A820E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */; };
 		071123A920E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */; };
-		079F41E820E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
-		079F41E920E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
-		079F41EA20E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
+		079F41E820E42EEF007EEB5E /* BatchGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchGeocodingTests.swift */; };
+		079F41E920E42EEF007EEB5E /* BatchGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchGeocodingTests.swift */; };
+		079F41EA20E42EEF007EEB5E /* BatchGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchGeocodingTests.swift */; };
+		07CF858220EC60B8007B26B6 /* permanent_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858120EC60B8007B26B6 /* permanent_invalid.json */; };
+		07CF858320EC60B8007B26B6 /* permanent_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858120EC60B8007B26B6 /* permanent_invalid.json */; };
+		07CF858420EC60B8007B26B6 /* permanent_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858120EC60B8007B26B6 /* permanent_invalid.json */; };
+		07CF858620EC6382007B26B6 /* permanent_invalid_token.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858520EC6382007B26B6 /* permanent_invalid_token.json */; };
+		07CF858720EC6382007B26B6 /* permanent_invalid_token.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858520EC6382007B26B6 /* permanent_invalid_token.json */; };
+		07CF858820EC6382007B26B6 /* permanent_invalid_token.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858520EC6382007B26B6 /* permanent_invalid_token.json */; };
+		07CF858A20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */; };
+		07CF858B20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */; };
+		07CF858C20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */; };
 		35506B8B200F856400629509 /* BridgingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35506B8A200F856400629509 /* BridgingTests.m */; };
 		35506B8C200F856400629509 /* BridgingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35506B8A200F856400629509 /* BridgingTests.m */; };
 		35506B8D200F856400629509 /* BridgingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35506B8A200F856400629509 /* BridgingTests.m */; };
@@ -189,7 +198,10 @@
 		0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_multiple_valid.json; path = ../../../../Desktop/permanent_forward_multiple_valid.json; sourceTree = "<group>"; };
 		071123A220E6EC7F0043CB51 /* permanent_forward_multiple_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_multiple_no_results.json; path = ../../../../Desktop/permanent_forward_multiple_no_results.json; sourceTree = "<group>"; };
 		071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_single_no_results.json; path = ../../../../Desktop/permanent_forward_single_no_results.json; sourceTree = "<group>"; };
-		079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchForwardGeocodingTests.swift; sourceTree = "<group>"; };
+		079F41E720E42EEF007EEB5E /* BatchGeocodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchGeocodingTests.swift; sourceTree = "<group>"; };
+		07CF858120EC60B8007B26B6 /* permanent_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_invalid.json; path = ../../../../Desktop/permanent_invalid.json; sourceTree = "<group>"; };
+		07CF858520EC6382007B26B6 /* permanent_invalid_token.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_invalid_token.json; path = ../../../../Desktop/permanent_invalid_token.json; sourceTree = "<group>"; };
+		07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_invalid_token_scope.json; path = ../../../../Desktop/permanent_invalid_token_scope.json; sourceTree = "<group>"; };
 		35506B8A200F856400629509 /* BridgingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BridgingTests.m; sourceTree = "<group>"; };
 		357B4357202CC90A00735521 /* reverse_address.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reverse_address.json; sourceTree = "<group>"; };
 		DA1AC0211E5C23B8006DF1D6 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
@@ -422,7 +434,7 @@
 		DDF1E84B1BD6F7BA00C40C78 /* MapboxGeocoderTests */ = {
 			isa = PBXGroup;
 			children = (
-				079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */,
+				079F41E720E42EEF007EEB5E /* BatchGeocodingTests.swift */,
 				DA701C001CB1292C00B0E520 /* GeocoderTests.swift */,
 				DA210BAA1CB4BE73008088FD /* ForwardGeocodingTests.swift */,
 				DDF1E84C1BD6F7BA00C40C78 /* ReverseGeocodingTests.swift */,
@@ -437,6 +449,9 @@
 		DDF1E8571BD700EB00C40C78 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
+				07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */,
+				07CF858520EC6382007B26B6 /* permanent_invalid_token.json */,
+				07CF858120EC60B8007B26B6 /* permanent_invalid.json */,
 				071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */,
 				071123A220E6EC7F0043CB51 /* permanent_forward_multiple_no_results.json */,
 				0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */,
@@ -751,6 +766,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07CF858720EC6382007B26B6 /* permanent_invalid_token.json in Resources */,
 				071123A820E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */,
 				071123A420E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */,
 				DA5170B81CF1B1F900CD6DCF /* forward_valid.json in Resources */,
@@ -758,7 +774,9 @@
 				DA5170B91CF1B1F900CD6DCF /* forward_invalid.json in Resources */,
 				DA5170BB1CF1B1F900CD6DCF /* reverse_invalid.json in Resources */,
 				DA5170BA1CF1B1F900CD6DCF /* reverse_valid.json in Resources */,
+				07CF858B20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */,
 				071123A020E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */,
+				07CF858320EC60B8007B26B6 /* permanent_invalid.json in Resources */,
 				0711239420E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A21DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
 			);
@@ -775,6 +793,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07CF858820EC6382007B26B6 /* permanent_invalid_token.json in Resources */,
 				071123A920E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */,
 				071123A520E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */,
 				DA5170E21CF2542B00CD6DCF /* forward_valid.json in Resources */,
@@ -782,7 +801,9 @@
 				DA5170E31CF2542B00CD6DCF /* forward_invalid.json in Resources */,
 				DA5170E51CF2542B00CD6DCF /* reverse_invalid.json in Resources */,
 				DA5170E41CF2542B00CD6DCF /* reverse_valid.json in Resources */,
+				07CF858C20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */,
 				071123A120E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */,
+				07CF858420EC60B8007B26B6 /* permanent_invalid.json in Resources */,
 				0711239520E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A31DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
 			);
@@ -822,6 +843,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07CF858620EC6382007B26B6 /* permanent_invalid_token.json in Resources */,
 				071123A720E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */,
 				071123A320E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */,
 				DA210BAD1CB4BFF7008088FD /* forward_valid.json in Resources */,
@@ -829,7 +851,9 @@
 				DDF1E85C1BD70E4C00C40C78 /* reverse_invalid.json in Resources */,
 				DDF1E85D1BD70E4C00C40C78 /* reverse_valid.json in Resources */,
 				DA210BAF1CB4C5A7008088FD /* forward_invalid.json in Resources */,
+				07CF858A20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */,
 				0711239F20E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */,
+				07CF858220EC60B8007B26B6 /* permanent_invalid.json in Resources */,
 				0711239320E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A11DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
 			);
@@ -922,7 +946,7 @@
 				DA5170B61CF1B1EF00CD6DCF /* ReverseGeocodingTests.swift in Sources */,
 				DA4D90081DD63AEC006EC71A /* PlacemarkScopeTests.swift in Sources */,
 				DA5170B41CF1B1EF00CD6DCF /* GeocoderTests.swift in Sources */,
-				079F41E920E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */,
+				079F41E920E42EEF007EEB5E /* BatchGeocodingTests.swift in Sources */,
 				DA5170B51CF1B1EF00CD6DCF /* ForwardGeocodingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -947,7 +971,7 @@
 				DA5170E11CF2542800CD6DCF /* ReverseGeocodingTests.swift in Sources */,
 				DA4D90091DD63AEC006EC71A /* PlacemarkScopeTests.swift in Sources */,
 				DA5170DF1CF2542800CD6DCF /* GeocoderTests.swift in Sources */,
-				079F41EA20E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */,
+				079F41EA20E42EEF007EEB5E /* BatchGeocodingTests.swift in Sources */,
 				DA5170E01CF2542800CD6DCF /* ForwardGeocodingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1003,7 +1027,7 @@
 				DDF1E84D1BD6F7BA00C40C78 /* ReverseGeocodingTests.swift in Sources */,
 				DA4D90071DD63AEC006EC71A /* PlacemarkScopeTests.swift in Sources */,
 				DA210BAB1CB4BE73008088FD /* ForwardGeocodingTests.swift in Sources */,
-				079F41E820E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */,
+				079F41E820E42EEF007EEB5E /* BatchGeocodingTests.swift in Sources */,
 				DA701C011CB1292C00B0E520 /* GeocoderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -13,12 +13,12 @@
 		0711239F20E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */; };
 		071123A020E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */; };
 		071123A120E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */; };
-		071123A320E6EC800043CB51 /* permanent_forward_multiple_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A220E6EC7F0043CB51 /* permanent_forward_multiple_invalid.json */; };
-		071123A420E6EC800043CB51 /* permanent_forward_multiple_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A220E6EC7F0043CB51 /* permanent_forward_multiple_invalid.json */; };
-		071123A520E6EC800043CB51 /* permanent_forward_multiple_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A220E6EC7F0043CB51 /* permanent_forward_multiple_invalid.json */; };
-		071123A720E6EC890043CB51 /* permanent_forward_single_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_invalid.json */; };
-		071123A820E6EC890043CB51 /* permanent_forward_single_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_invalid.json */; };
-		071123A920E6EC890043CB51 /* permanent_forward_single_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_invalid.json */; };
+		071123A320E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A220E6EC7F0043CB51 /* permanent_forward_multiple_no_results.json */; };
+		071123A420E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A220E6EC7F0043CB51 /* permanent_forward_multiple_no_results.json */; };
+		071123A520E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A220E6EC7F0043CB51 /* permanent_forward_multiple_no_results.json */; };
+		071123A720E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */; };
+		071123A820E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */; };
+		071123A920E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */; };
 		079F41E820E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
 		079F41E920E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
 		079F41EA20E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
@@ -187,8 +187,8 @@
 /* Begin PBXFileReference section */
 		0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_single_valid.json; path = ../../../../.Trash/permanent_forward_single_valid.json; sourceTree = "<group>"; };
 		0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_multiple_valid.json; path = ../../../../Desktop/permanent_forward_multiple_valid.json; sourceTree = "<group>"; };
-		071123A220E6EC7F0043CB51 /* permanent_forward_multiple_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_multiple_invalid.json; path = ../../../../Desktop/permanent_forward_multiple_invalid.json; sourceTree = "<group>"; };
-		071123A620E6EC880043CB51 /* permanent_forward_single_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_single_invalid.json; path = ../../../../Desktop/permanent_forward_single_invalid.json; sourceTree = "<group>"; };
+		071123A220E6EC7F0043CB51 /* permanent_forward_multiple_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_multiple_no_results.json; path = ../../../../Desktop/permanent_forward_multiple_no_results.json; sourceTree = "<group>"; };
+		071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_single_no_results.json; path = ../../../../Desktop/permanent_forward_single_no_results.json; sourceTree = "<group>"; };
 		079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchForwardGeocodingTests.swift; sourceTree = "<group>"; };
 		35506B8A200F856400629509 /* BridgingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BridgingTests.m; sourceTree = "<group>"; };
 		357B4357202CC90A00735521 /* reverse_address.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reverse_address.json; sourceTree = "<group>"; };
@@ -437,8 +437,8 @@
 		DDF1E8571BD700EB00C40C78 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
-				071123A620E6EC880043CB51 /* permanent_forward_single_invalid.json */,
-				071123A220E6EC7F0043CB51 /* permanent_forward_multiple_invalid.json */,
+				071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */,
+				071123A220E6EC7F0043CB51 /* permanent_forward_multiple_no_results.json */,
 				0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */,
 				0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */,
 				DA210BAC1CB4BFF7008088FD /* forward_valid.json */,
@@ -751,8 +751,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				071123A820E6EC890043CB51 /* permanent_forward_single_invalid.json in Resources */,
-				071123A420E6EC800043CB51 /* permanent_forward_multiple_invalid.json in Resources */,
+				071123A820E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */,
+				071123A420E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */,
 				DA5170B81CF1B1F900CD6DCF /* forward_valid.json in Resources */,
 				357B4359202CC90A00735521 /* reverse_address.json in Resources */,
 				DA5170B91CF1B1F900CD6DCF /* forward_invalid.json in Resources */,
@@ -775,8 +775,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				071123A920E6EC890043CB51 /* permanent_forward_single_invalid.json in Resources */,
-				071123A520E6EC800043CB51 /* permanent_forward_multiple_invalid.json in Resources */,
+				071123A920E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */,
+				071123A520E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */,
 				DA5170E21CF2542B00CD6DCF /* forward_valid.json in Resources */,
 				357B435A202CC90A00735521 /* reverse_address.json in Resources */,
 				DA5170E31CF2542B00CD6DCF /* forward_invalid.json in Resources */,
@@ -822,8 +822,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				071123A720E6EC890043CB51 /* permanent_forward_single_invalid.json in Resources */,
-				071123A320E6EC800043CB51 /* permanent_forward_multiple_invalid.json in Resources */,
+				071123A720E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */,
+				071123A320E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */,
 				DA210BAD1CB4BFF7008088FD /* forward_valid.json in Resources */,
 				357B4358202CC90A00735521 /* reverse_address.json in Resources */,
 				DDF1E85C1BD70E4C00C40C78 /* reverse_invalid.json in Resources */,

--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -13,6 +13,12 @@
 		0711239F20E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */; };
 		071123A020E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */; };
 		071123A120E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */; };
+		071123A320E6EC800043CB51 /* permanent_forward_multiple_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A220E6EC7F0043CB51 /* permanent_forward_multiple_invalid.json */; };
+		071123A420E6EC800043CB51 /* permanent_forward_multiple_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A220E6EC7F0043CB51 /* permanent_forward_multiple_invalid.json */; };
+		071123A520E6EC800043CB51 /* permanent_forward_multiple_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A220E6EC7F0043CB51 /* permanent_forward_multiple_invalid.json */; };
+		071123A720E6EC890043CB51 /* permanent_forward_single_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_invalid.json */; };
+		071123A820E6EC890043CB51 /* permanent_forward_single_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_invalid.json */; };
+		071123A920E6EC890043CB51 /* permanent_forward_single_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_invalid.json */; };
 		079F41E820E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
 		079F41E920E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
 		079F41EA20E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
@@ -181,6 +187,8 @@
 /* Begin PBXFileReference section */
 		0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_single_valid.json; path = ../../../../.Trash/permanent_forward_single_valid.json; sourceTree = "<group>"; };
 		0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_multiple_valid.json; path = ../../../../Desktop/permanent_forward_multiple_valid.json; sourceTree = "<group>"; };
+		071123A220E6EC7F0043CB51 /* permanent_forward_multiple_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_multiple_invalid.json; path = ../../../../Desktop/permanent_forward_multiple_invalid.json; sourceTree = "<group>"; };
+		071123A620E6EC880043CB51 /* permanent_forward_single_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_single_invalid.json; path = ../../../../Desktop/permanent_forward_single_invalid.json; sourceTree = "<group>"; };
 		079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchForwardGeocodingTests.swift; sourceTree = "<group>"; };
 		35506B8A200F856400629509 /* BridgingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BridgingTests.m; sourceTree = "<group>"; };
 		357B4357202CC90A00735521 /* reverse_address.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reverse_address.json; sourceTree = "<group>"; };
@@ -429,6 +437,8 @@
 		DDF1E8571BD700EB00C40C78 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
+				071123A620E6EC880043CB51 /* permanent_forward_single_invalid.json */,
+				071123A220E6EC7F0043CB51 /* permanent_forward_multiple_invalid.json */,
 				0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */,
 				0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */,
 				DA210BAC1CB4BFF7008088FD /* forward_valid.json */,
@@ -741,6 +751,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				071123A820E6EC890043CB51 /* permanent_forward_single_invalid.json in Resources */,
+				071123A420E6EC800043CB51 /* permanent_forward_multiple_invalid.json in Resources */,
 				DA5170B81CF1B1F900CD6DCF /* forward_valid.json in Resources */,
 				357B4359202CC90A00735521 /* reverse_address.json in Resources */,
 				DA5170B91CF1B1F900CD6DCF /* forward_invalid.json in Resources */,
@@ -763,6 +775,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				071123A920E6EC890043CB51 /* permanent_forward_single_invalid.json in Resources */,
+				071123A520E6EC800043CB51 /* permanent_forward_multiple_invalid.json in Resources */,
 				DA5170E21CF2542B00CD6DCF /* forward_valid.json in Resources */,
 				357B435A202CC90A00735521 /* reverse_address.json in Resources */,
 				DA5170E31CF2542B00CD6DCF /* forward_invalid.json in Resources */,
@@ -808,6 +822,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				071123A720E6EC890043CB51 /* permanent_forward_single_invalid.json in Resources */,
+				071123A320E6EC800043CB51 /* permanent_forward_multiple_invalid.json in Resources */,
 				DA210BAD1CB4BFF7008088FD /* forward_valid.json in Resources */,
 				357B4358202CC90A00735521 /* reverse_address.json in Resources */,
 				DDF1E85C1BD70E4C00C40C78 /* reverse_invalid.json in Resources */,

--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -31,6 +31,18 @@
 		07CF858A20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */; };
 		07CF858B20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */; };
 		07CF858C20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */; };
+		07CF858E20EEB626007B26B6 /* permanent_reverse_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858D20EEB625007B26B6 /* permanent_reverse_single_valid.json */; };
+		07CF858F20EEB626007B26B6 /* permanent_reverse_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858D20EEB625007B26B6 /* permanent_reverse_single_valid.json */; };
+		07CF859020EEB626007B26B6 /* permanent_reverse_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858D20EEB625007B26B6 /* permanent_reverse_single_valid.json */; };
+		07CF859220EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859120EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json */; };
+		07CF859320EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859120EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json */; };
+		07CF859420EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859120EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json */; };
+		07CF859620EEC0E4007B26B6 /* permanent_reverse_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859520EEC0E3007B26B6 /* permanent_reverse_single_no_results.json */; };
+		07CF859720EEC0E4007B26B6 /* permanent_reverse_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859520EEC0E3007B26B6 /* permanent_reverse_single_no_results.json */; };
+		07CF859820EEC0E4007B26B6 /* permanent_reverse_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859520EEC0E3007B26B6 /* permanent_reverse_single_no_results.json */; };
+		07CF859A20EECE90007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859920EECE8F007B26B6 /* permanent_reverse_multiple_no_results.json */; };
+		07CF859B20EECE90007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859920EECE8F007B26B6 /* permanent_reverse_multiple_no_results.json */; };
+		07CF859C20EECE90007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859920EECE8F007B26B6 /* permanent_reverse_multiple_no_results.json */; };
 		35506B8B200F856400629509 /* BridgingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35506B8A200F856400629509 /* BridgingTests.m */; };
 		35506B8C200F856400629509 /* BridgingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35506B8A200F856400629509 /* BridgingTests.m */; };
 		35506B8D200F856400629509 /* BridgingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35506B8A200F856400629509 /* BridgingTests.m */; };
@@ -202,6 +214,10 @@
 		07CF858120EC60B8007B26B6 /* permanent_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_invalid.json; path = ../../../../Desktop/permanent_invalid.json; sourceTree = "<group>"; };
 		07CF858520EC6382007B26B6 /* permanent_invalid_token.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_invalid_token.json; path = ../../../../Desktop/permanent_invalid_token.json; sourceTree = "<group>"; };
 		07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_invalid_token_scope.json; path = ../../../../Desktop/permanent_invalid_token_scope.json; sourceTree = "<group>"; };
+		07CF858D20EEB625007B26B6 /* permanent_reverse_single_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_reverse_single_valid.json; path = ../../../../Desktop/permanent_reverse_single_valid.json; sourceTree = "<group>"; };
+		07CF859120EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_reverse_multiple_valid.json; path = ../../../../Desktop/permanent_reverse_multiple_valid.json; sourceTree = "<group>"; };
+		07CF859520EEC0E3007B26B6 /* permanent_reverse_single_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_reverse_single_no_results.json; path = ../../../../Desktop/permanent_reverse_single_no_results.json; sourceTree = "<group>"; };
+		07CF859920EECE8F007B26B6 /* permanent_reverse_multiple_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_reverse_multiple_no_results.json; path = ../../../../Desktop/permanent_reverse_multiple_no_results.json; sourceTree = "<group>"; };
 		35506B8A200F856400629509 /* BridgingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BridgingTests.m; sourceTree = "<group>"; };
 		357B4357202CC90A00735521 /* reverse_address.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reverse_address.json; sourceTree = "<group>"; };
 		DA1AC0211E5C23B8006DF1D6 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
@@ -456,6 +472,10 @@
 				071123A220E6EC7F0043CB51 /* permanent_forward_multiple_no_results.json */,
 				0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */,
 				0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */,
+				07CF858D20EEB625007B26B6 /* permanent_reverse_single_valid.json */,
+				07CF859120EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json */,
+				07CF859520EEC0E3007B26B6 /* permanent_reverse_single_no_results.json */,
+				07CF859920EECE8F007B26B6 /* permanent_reverse_multiple_no_results.json */,
 				DA210BAC1CB4BFF7008088FD /* forward_valid.json */,
 				DA58D8A01DB2ADDD00530CBB /* forward_valid_zh.json */,
 				DA210BAE1CB4C5A7008088FD /* forward_invalid.json */,
@@ -767,7 +787,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				07CF858720EC6382007B26B6 /* permanent_invalid_token.json in Resources */,
+				07CF859B20EECE90007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */,
+				07CF859320EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json in Resources */,
 				071123A820E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */,
+				07CF859720EEC0E4007B26B6 /* permanent_reverse_single_no_results.json in Resources */,
 				071123A420E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */,
 				DA5170B81CF1B1F900CD6DCF /* forward_valid.json in Resources */,
 				357B4359202CC90A00735521 /* reverse_address.json in Resources */,
@@ -776,6 +799,7 @@
 				DA5170BA1CF1B1F900CD6DCF /* reverse_valid.json in Resources */,
 				07CF858B20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */,
 				071123A020E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */,
+				07CF858F20EEB626007B26B6 /* permanent_reverse_single_valid.json in Resources */,
 				07CF858320EC60B8007B26B6 /* permanent_invalid.json in Resources */,
 				0711239420E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A21DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
@@ -794,7 +818,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				07CF858820EC6382007B26B6 /* permanent_invalid_token.json in Resources */,
+				07CF859C20EECE90007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */,
+				07CF859420EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json in Resources */,
 				071123A920E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */,
+				07CF859820EEC0E4007B26B6 /* permanent_reverse_single_no_results.json in Resources */,
 				071123A520E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */,
 				DA5170E21CF2542B00CD6DCF /* forward_valid.json in Resources */,
 				357B435A202CC90A00735521 /* reverse_address.json in Resources */,
@@ -803,6 +830,7 @@
 				DA5170E41CF2542B00CD6DCF /* reverse_valid.json in Resources */,
 				07CF858C20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */,
 				071123A120E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */,
+				07CF859020EEB626007B26B6 /* permanent_reverse_single_valid.json in Resources */,
 				07CF858420EC60B8007B26B6 /* permanent_invalid.json in Resources */,
 				0711239520E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A31DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
@@ -844,7 +872,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				07CF858620EC6382007B26B6 /* permanent_invalid_token.json in Resources */,
+				07CF859A20EECE90007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */,
+				07CF859220EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json in Resources */,
 				071123A720E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */,
+				07CF859620EEC0E4007B26B6 /* permanent_reverse_single_no_results.json in Resources */,
 				071123A320E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */,
 				DA210BAD1CB4BFF7008088FD /* forward_valid.json in Resources */,
 				357B4358202CC90A00735521 /* reverse_address.json in Resources */,
@@ -853,6 +884,7 @@
 				DA210BAF1CB4C5A7008088FD /* forward_invalid.json in Resources */,
 				07CF858A20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */,
 				0711239F20E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */,
+				07CF858E20EEB626007B26B6 /* permanent_reverse_single_valid.json in Resources */,
 				07CF858220EC60B8007B26B6 /* permanent_invalid.json in Resources */,
 				0711239320E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A11DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,

--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -7,42 +7,42 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0711239320E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */; };
-		0711239420E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */; };
-		0711239520E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */; };
-		0711239F20E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */; };
-		071123A020E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */; };
-		071123A120E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */; };
-		071123A320E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A220E6EC7F0043CB51 /* permanent_forward_multiple_no_results.json */; };
-		071123A420E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A220E6EC7F0043CB51 /* permanent_forward_multiple_no_results.json */; };
-		071123A520E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A220E6EC7F0043CB51 /* permanent_forward_multiple_no_results.json */; };
-		071123A720E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */; };
-		071123A820E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */; };
-		071123A920E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */; };
 		079F41E820E42EEF007EEB5E /* BatchGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchGeocodingTests.swift */; };
 		079F41E920E42EEF007EEB5E /* BatchGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchGeocodingTests.swift */; };
 		079F41EA20E42EEF007EEB5E /* BatchGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchGeocodingTests.swift */; };
-		07CF858220EC60B8007B26B6 /* permanent_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858120EC60B8007B26B6 /* permanent_invalid.json */; };
-		07CF858320EC60B8007B26B6 /* permanent_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858120EC60B8007B26B6 /* permanent_invalid.json */; };
-		07CF858420EC60B8007B26B6 /* permanent_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858120EC60B8007B26B6 /* permanent_invalid.json */; };
-		07CF858620EC6382007B26B6 /* permanent_invalid_token.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858520EC6382007B26B6 /* permanent_invalid_token.json */; };
-		07CF858720EC6382007B26B6 /* permanent_invalid_token.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858520EC6382007B26B6 /* permanent_invalid_token.json */; };
-		07CF858820EC6382007B26B6 /* permanent_invalid_token.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858520EC6382007B26B6 /* permanent_invalid_token.json */; };
-		07CF858A20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */; };
-		07CF858B20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */; };
-		07CF858C20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */; };
-		07CF858E20EEB626007B26B6 /* permanent_reverse_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858D20EEB625007B26B6 /* permanent_reverse_single_valid.json */; };
-		07CF858F20EEB626007B26B6 /* permanent_reverse_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858D20EEB625007B26B6 /* permanent_reverse_single_valid.json */; };
-		07CF859020EEB626007B26B6 /* permanent_reverse_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF858D20EEB625007B26B6 /* permanent_reverse_single_valid.json */; };
-		07CF859220EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859120EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json */; };
-		07CF859320EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859120EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json */; };
-		07CF859420EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859120EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json */; };
-		07CF859620EEC0E4007B26B6 /* permanent_reverse_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859520EEC0E3007B26B6 /* permanent_reverse_single_no_results.json */; };
-		07CF859720EEC0E4007B26B6 /* permanent_reverse_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859520EEC0E3007B26B6 /* permanent_reverse_single_no_results.json */; };
-		07CF859820EEC0E4007B26B6 /* permanent_reverse_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859520EEC0E3007B26B6 /* permanent_reverse_single_no_results.json */; };
-		07CF859A20EECE90007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859920EECE8F007B26B6 /* permanent_reverse_multiple_no_results.json */; };
-		07CF859B20EECE90007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859920EECE8F007B26B6 /* permanent_reverse_multiple_no_results.json */; };
-		07CF859C20EECE90007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859920EECE8F007B26B6 /* permanent_reverse_multiple_no_results.json */; };
+		07CF859F20F6DE61007B26B6 /* permanent_invalid_token.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859E20F6DE61007B26B6 /* permanent_invalid_token.json */; };
+		07CF85A020F6DE61007B26B6 /* permanent_invalid_token.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859E20F6DE61007B26B6 /* permanent_invalid_token.json */; };
+		07CF85A120F6DE61007B26B6 /* permanent_invalid_token.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF859E20F6DE61007B26B6 /* permanent_invalid_token.json */; };
+		07CF85A320F6DED8007B26B6 /* permanent_invalid_token_scope.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85A220F6DED8007B26B6 /* permanent_invalid_token_scope.json */; };
+		07CF85A420F6DED8007B26B6 /* permanent_invalid_token_scope.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85A220F6DED8007B26B6 /* permanent_invalid_token_scope.json */; };
+		07CF85A520F6DED8007B26B6 /* permanent_invalid_token_scope.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85A220F6DED8007B26B6 /* permanent_invalid_token_scope.json */; };
+		07CF85A720F6DF0F007B26B6 /* permanent_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85A620F6DF0E007B26B6 /* permanent_invalid.json */; };
+		07CF85A820F6DF0F007B26B6 /* permanent_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85A620F6DF0E007B26B6 /* permanent_invalid.json */; };
+		07CF85A920F6DF0F007B26B6 /* permanent_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85A620F6DF0E007B26B6 /* permanent_invalid.json */; };
+		07CF85AB20F6DF1E007B26B6 /* permanent_forward_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85AA20F6DF1D007B26B6 /* permanent_forward_single_no_results.json */; };
+		07CF85AC20F6DF1E007B26B6 /* permanent_forward_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85AA20F6DF1D007B26B6 /* permanent_forward_single_no_results.json */; };
+		07CF85AD20F6DF1E007B26B6 /* permanent_forward_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85AA20F6DF1D007B26B6 /* permanent_forward_single_no_results.json */; };
+		07CF85AF20F6DF2F007B26B6 /* permanent_forward_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85AE20F6DF2F007B26B6 /* permanent_forward_multiple_no_results.json */; };
+		07CF85B020F6DF2F007B26B6 /* permanent_forward_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85AE20F6DF2F007B26B6 /* permanent_forward_multiple_no_results.json */; };
+		07CF85B120F6DF2F007B26B6 /* permanent_forward_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85AE20F6DF2F007B26B6 /* permanent_forward_multiple_no_results.json */; };
+		07CF85B320F6DF3C007B26B6 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85B220F6DF3C007B26B6 /* permanent_forward_multiple_valid.json */; };
+		07CF85B420F6DF3C007B26B6 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85B220F6DF3C007B26B6 /* permanent_forward_multiple_valid.json */; };
+		07CF85B520F6DF3C007B26B6 /* permanent_forward_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85B220F6DF3C007B26B6 /* permanent_forward_multiple_valid.json */; };
+		07CF85B720F6DF55007B26B6 /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85B620F6DF55007B26B6 /* permanent_forward_single_valid.json */; };
+		07CF85B820F6DF55007B26B6 /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85B620F6DF55007B26B6 /* permanent_forward_single_valid.json */; };
+		07CF85B920F6DF55007B26B6 /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85B620F6DF55007B26B6 /* permanent_forward_single_valid.json */; };
+		07CF85BB20F6DF76007B26B6 /* permanent_reverse_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85BA20F6DF76007B26B6 /* permanent_reverse_multiple_valid.json */; };
+		07CF85BC20F6DF76007B26B6 /* permanent_reverse_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85BA20F6DF76007B26B6 /* permanent_reverse_multiple_valid.json */; };
+		07CF85BD20F6DF76007B26B6 /* permanent_reverse_multiple_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85BA20F6DF76007B26B6 /* permanent_reverse_multiple_valid.json */; };
+		07CF85BF20F6DF86007B26B6 /* permanent_reverse_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85BE20F6DF86007B26B6 /* permanent_reverse_single_no_results.json */; };
+		07CF85C020F6DF86007B26B6 /* permanent_reverse_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85BE20F6DF86007B26B6 /* permanent_reverse_single_no_results.json */; };
+		07CF85C120F6DF86007B26B6 /* permanent_reverse_single_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85BE20F6DF86007B26B6 /* permanent_reverse_single_no_results.json */; };
+		07CF85C320F6DF93007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85C220F6DF93007B26B6 /* permanent_reverse_multiple_no_results.json */; };
+		07CF85C420F6DF93007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85C220F6DF93007B26B6 /* permanent_reverse_multiple_no_results.json */; };
+		07CF85C520F6DF93007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85C220F6DF93007B26B6 /* permanent_reverse_multiple_no_results.json */; };
+		07CF85C720F6DFEB007B26B6 /* permanent_reverse_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85C620F6DFEB007B26B6 /* permanent_reverse_single_valid.json */; };
+		07CF85C820F6DFEB007B26B6 /* permanent_reverse_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85C620F6DFEB007B26B6 /* permanent_reverse_single_valid.json */; };
+		07CF85C920F6DFEB007B26B6 /* permanent_reverse_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 07CF85C620F6DFEB007B26B6 /* permanent_reverse_single_valid.json */; };
 		35506B8B200F856400629509 /* BridgingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35506B8A200F856400629509 /* BridgingTests.m */; };
 		35506B8C200F856400629509 /* BridgingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35506B8A200F856400629509 /* BridgingTests.m */; };
 		35506B8D200F856400629509 /* BridgingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35506B8A200F856400629509 /* BridgingTests.m */; };
@@ -206,18 +206,18 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_single_valid.json; path = ../../../../.Trash/permanent_forward_single_valid.json; sourceTree = "<group>"; };
-		0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_multiple_valid.json; path = ../../../../Desktop/permanent_forward_multiple_valid.json; sourceTree = "<group>"; };
-		071123A220E6EC7F0043CB51 /* permanent_forward_multiple_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_multiple_no_results.json; path = ../../../../Desktop/permanent_forward_multiple_no_results.json; sourceTree = "<group>"; };
-		071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_single_no_results.json; path = ../../../../Desktop/permanent_forward_single_no_results.json; sourceTree = "<group>"; };
 		079F41E720E42EEF007EEB5E /* BatchGeocodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchGeocodingTests.swift; sourceTree = "<group>"; };
-		07CF858120EC60B8007B26B6 /* permanent_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_invalid.json; path = ../../../../Desktop/permanent_invalid.json; sourceTree = "<group>"; };
-		07CF858520EC6382007B26B6 /* permanent_invalid_token.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_invalid_token.json; path = ../../../../Desktop/permanent_invalid_token.json; sourceTree = "<group>"; };
-		07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_invalid_token_scope.json; path = ../../../../Desktop/permanent_invalid_token_scope.json; sourceTree = "<group>"; };
-		07CF858D20EEB625007B26B6 /* permanent_reverse_single_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_reverse_single_valid.json; path = ../../../../Desktop/permanent_reverse_single_valid.json; sourceTree = "<group>"; };
-		07CF859120EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_reverse_multiple_valid.json; path = ../../../../Desktop/permanent_reverse_multiple_valid.json; sourceTree = "<group>"; };
-		07CF859520EEC0E3007B26B6 /* permanent_reverse_single_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_reverse_single_no_results.json; path = ../../../../Desktop/permanent_reverse_single_no_results.json; sourceTree = "<group>"; };
-		07CF859920EECE8F007B26B6 /* permanent_reverse_multiple_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_reverse_multiple_no_results.json; path = ../../../../Desktop/permanent_reverse_multiple_no_results.json; sourceTree = "<group>"; };
+		07CF859E20F6DE61007B26B6 /* permanent_invalid_token.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = permanent_invalid_token.json; sourceTree = "<group>"; };
+		07CF85A220F6DED8007B26B6 /* permanent_invalid_token_scope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = permanent_invalid_token_scope.json; sourceTree = "<group>"; };
+		07CF85A620F6DF0E007B26B6 /* permanent_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = permanent_invalid.json; sourceTree = "<group>"; };
+		07CF85AA20F6DF1D007B26B6 /* permanent_forward_single_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = permanent_forward_single_no_results.json; sourceTree = "<group>"; };
+		07CF85AE20F6DF2F007B26B6 /* permanent_forward_multiple_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = permanent_forward_multiple_no_results.json; sourceTree = "<group>"; };
+		07CF85B220F6DF3C007B26B6 /* permanent_forward_multiple_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = permanent_forward_multiple_valid.json; sourceTree = "<group>"; };
+		07CF85B620F6DF55007B26B6 /* permanent_forward_single_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = permanent_forward_single_valid.json; sourceTree = "<group>"; };
+		07CF85BA20F6DF76007B26B6 /* permanent_reverse_multiple_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = permanent_reverse_multiple_valid.json; sourceTree = "<group>"; };
+		07CF85BE20F6DF86007B26B6 /* permanent_reverse_single_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = permanent_reverse_single_no_results.json; sourceTree = "<group>"; };
+		07CF85C220F6DF93007B26B6 /* permanent_reverse_multiple_no_results.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = permanent_reverse_multiple_no_results.json; sourceTree = "<group>"; };
+		07CF85C620F6DFEB007B26B6 /* permanent_reverse_single_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = permanent_reverse_single_valid.json; sourceTree = "<group>"; };
 		35506B8A200F856400629509 /* BridgingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BridgingTests.m; sourceTree = "<group>"; };
 		357B4357202CC90A00735521 /* reverse_address.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reverse_address.json; sourceTree = "<group>"; };
 		DA1AC0211E5C23B8006DF1D6 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
@@ -465,17 +465,17 @@
 		DDF1E8571BD700EB00C40C78 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
-				07CF858920EC647F007B26B6 /* permanent_invalid_token_scope.json */,
-				07CF858520EC6382007B26B6 /* permanent_invalid_token.json */,
-				07CF858120EC60B8007B26B6 /* permanent_invalid.json */,
-				071123A620E6EC880043CB51 /* permanent_forward_single_no_results.json */,
-				071123A220E6EC7F0043CB51 /* permanent_forward_multiple_no_results.json */,
-				0711239E20E5A53E0043CB51 /* permanent_forward_multiple_valid.json */,
-				0711239220E59DE90043CB51 /* permanent_forward_single_valid.json */,
-				07CF858D20EEB625007B26B6 /* permanent_reverse_single_valid.json */,
-				07CF859120EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json */,
-				07CF859520EEC0E3007B26B6 /* permanent_reverse_single_no_results.json */,
-				07CF859920EECE8F007B26B6 /* permanent_reverse_multiple_no_results.json */,
+				07CF85A220F6DED8007B26B6 /* permanent_invalid_token_scope.json */,
+				07CF859E20F6DE61007B26B6 /* permanent_invalid_token.json */,
+				07CF85A620F6DF0E007B26B6 /* permanent_invalid.json */,
+				07CF85AA20F6DF1D007B26B6 /* permanent_forward_single_no_results.json */,
+				07CF85AE20F6DF2F007B26B6 /* permanent_forward_multiple_no_results.json */,
+				07CF85B220F6DF3C007B26B6 /* permanent_forward_multiple_valid.json */,
+				07CF85B620F6DF55007B26B6 /* permanent_forward_single_valid.json */,
+				07CF85C620F6DFEB007B26B6 /* permanent_reverse_single_valid.json */,
+				07CF85BA20F6DF76007B26B6 /* permanent_reverse_multiple_valid.json */,
+				07CF85BE20F6DF86007B26B6 /* permanent_reverse_single_no_results.json */,
+				07CF85C220F6DF93007B26B6 /* permanent_reverse_multiple_no_results.json */,
 				DA210BAC1CB4BFF7008088FD /* forward_valid.json */,
 				DA58D8A01DB2ADDD00530CBB /* forward_valid_zh.json */,
 				DA210BAE1CB4C5A7008088FD /* forward_invalid.json */,
@@ -786,23 +786,23 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				07CF858720EC6382007B26B6 /* permanent_invalid_token.json in Resources */,
-				07CF859B20EECE90007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */,
-				07CF859320EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json in Resources */,
-				071123A820E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */,
-				07CF859720EEC0E4007B26B6 /* permanent_reverse_single_no_results.json in Resources */,
-				071123A420E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */,
+				07CF85B020F6DF2F007B26B6 /* permanent_forward_multiple_no_results.json in Resources */,
+				07CF85A820F6DF0F007B26B6 /* permanent_invalid.json in Resources */,
+				07CF85C020F6DF86007B26B6 /* permanent_reverse_single_no_results.json in Resources */,
 				DA5170B81CF1B1F900CD6DCF /* forward_valid.json in Resources */,
+				07CF85B420F6DF3C007B26B6 /* permanent_forward_multiple_valid.json in Resources */,
+				07CF85AC20F6DF1E007B26B6 /* permanent_forward_single_no_results.json in Resources */,
 				357B4359202CC90A00735521 /* reverse_address.json in Resources */,
+				07CF85C820F6DFEB007B26B6 /* permanent_reverse_single_valid.json in Resources */,
+				07CF85A020F6DE61007B26B6 /* permanent_invalid_token.json in Resources */,
 				DA5170B91CF1B1F900CD6DCF /* forward_invalid.json in Resources */,
 				DA5170BB1CF1B1F900CD6DCF /* reverse_invalid.json in Resources */,
 				DA5170BA1CF1B1F900CD6DCF /* reverse_valid.json in Resources */,
-				07CF858B20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */,
-				071123A020E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */,
-				07CF858F20EEB626007B26B6 /* permanent_reverse_single_valid.json in Resources */,
-				07CF858320EC60B8007B26B6 /* permanent_invalid.json in Resources */,
-				0711239420E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */,
+				07CF85BC20F6DF76007B26B6 /* permanent_reverse_multiple_valid.json in Resources */,
+				07CF85A420F6DED8007B26B6 /* permanent_invalid_token_scope.json in Resources */,
+				07CF85B820F6DF55007B26B6 /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A21DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
+				07CF85C420F6DF93007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -817,23 +817,23 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				07CF858820EC6382007B26B6 /* permanent_invalid_token.json in Resources */,
-				07CF859C20EECE90007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */,
-				07CF859420EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json in Resources */,
-				071123A920E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */,
-				07CF859820EEC0E4007B26B6 /* permanent_reverse_single_no_results.json in Resources */,
-				071123A520E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */,
+				07CF85B120F6DF2F007B26B6 /* permanent_forward_multiple_no_results.json in Resources */,
+				07CF85A920F6DF0F007B26B6 /* permanent_invalid.json in Resources */,
+				07CF85C120F6DF86007B26B6 /* permanent_reverse_single_no_results.json in Resources */,
 				DA5170E21CF2542B00CD6DCF /* forward_valid.json in Resources */,
+				07CF85B520F6DF3C007B26B6 /* permanent_forward_multiple_valid.json in Resources */,
+				07CF85AD20F6DF1E007B26B6 /* permanent_forward_single_no_results.json in Resources */,
 				357B435A202CC90A00735521 /* reverse_address.json in Resources */,
+				07CF85C920F6DFEB007B26B6 /* permanent_reverse_single_valid.json in Resources */,
+				07CF85A120F6DE61007B26B6 /* permanent_invalid_token.json in Resources */,
 				DA5170E31CF2542B00CD6DCF /* forward_invalid.json in Resources */,
 				DA5170E51CF2542B00CD6DCF /* reverse_invalid.json in Resources */,
 				DA5170E41CF2542B00CD6DCF /* reverse_valid.json in Resources */,
-				07CF858C20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */,
-				071123A120E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */,
-				07CF859020EEB626007B26B6 /* permanent_reverse_single_valid.json in Resources */,
-				07CF858420EC60B8007B26B6 /* permanent_invalid.json in Resources */,
-				0711239520E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */,
+				07CF85BD20F6DF76007B26B6 /* permanent_reverse_multiple_valid.json in Resources */,
+				07CF85A520F6DED8007B26B6 /* permanent_invalid_token_scope.json in Resources */,
+				07CF85B920F6DF55007B26B6 /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A31DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
+				07CF85C520F6DF93007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -871,23 +871,23 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				07CF858620EC6382007B26B6 /* permanent_invalid_token.json in Resources */,
-				07CF859A20EECE90007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */,
-				07CF859220EEBF2F007B26B6 /* permanent_reverse_multiple_valid.json in Resources */,
-				071123A720E6EC890043CB51 /* permanent_forward_single_no_results.json in Resources */,
-				07CF859620EEC0E4007B26B6 /* permanent_reverse_single_no_results.json in Resources */,
-				071123A320E6EC800043CB51 /* permanent_forward_multiple_no_results.json in Resources */,
+				07CF85AF20F6DF2F007B26B6 /* permanent_forward_multiple_no_results.json in Resources */,
+				07CF85A720F6DF0F007B26B6 /* permanent_invalid.json in Resources */,
+				07CF85BF20F6DF86007B26B6 /* permanent_reverse_single_no_results.json in Resources */,
 				DA210BAD1CB4BFF7008088FD /* forward_valid.json in Resources */,
+				07CF85B320F6DF3C007B26B6 /* permanent_forward_multiple_valid.json in Resources */,
+				07CF85AB20F6DF1E007B26B6 /* permanent_forward_single_no_results.json in Resources */,
 				357B4358202CC90A00735521 /* reverse_address.json in Resources */,
+				07CF85C720F6DFEB007B26B6 /* permanent_reverse_single_valid.json in Resources */,
+				07CF859F20F6DE61007B26B6 /* permanent_invalid_token.json in Resources */,
 				DDF1E85C1BD70E4C00C40C78 /* reverse_invalid.json in Resources */,
 				DDF1E85D1BD70E4C00C40C78 /* reverse_valid.json in Resources */,
 				DA210BAF1CB4C5A7008088FD /* forward_invalid.json in Resources */,
-				07CF858A20EC647F007B26B6 /* permanent_invalid_token_scope.json in Resources */,
-				0711239F20E5A53E0043CB51 /* permanent_forward_multiple_valid.json in Resources */,
-				07CF858E20EEB626007B26B6 /* permanent_reverse_single_valid.json in Resources */,
-				07CF858220EC60B8007B26B6 /* permanent_invalid.json in Resources */,
-				0711239320E59DEA0043CB51 /* permanent_forward_single_valid.json in Resources */,
+				07CF85BB20F6DF76007B26B6 /* permanent_reverse_multiple_valid.json in Resources */,
+				07CF85A320F6DED8007B26B6 /* permanent_invalid_token_scope.json in Resources */,
+				07CF85B720F6DF55007B26B6 /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A11DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
+				07CF85C320F6DF93007B26B6 /* permanent_reverse_multiple_no_results.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		079F41E420E42D7F007EEB5E /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 079F41E320E42D7F007EEB5E /* permanent_forward_single_valid.json */; };
+		079F41E520E42D7F007EEB5E /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 079F41E320E42D7F007EEB5E /* permanent_forward_single_valid.json */; };
+		079F41E620E42D7F007EEB5E /* permanent_forward_single_valid.json in Resources */ = {isa = PBXBuildFile; fileRef = 079F41E320E42D7F007EEB5E /* permanent_forward_single_valid.json */; };
+		079F41E820E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
+		079F41E920E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
+		079F41EA20E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */; };
 		35506B8B200F856400629509 /* BridgingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35506B8A200F856400629509 /* BridgingTests.m */; };
 		35506B8C200F856400629509 /* BridgingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35506B8A200F856400629509 /* BridgingTests.m */; };
 		35506B8D200F856400629509 /* BridgingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35506B8A200F856400629509 /* BridgingTests.m */; };
@@ -170,6 +176,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		079F41E320E42D7F007EEB5E /* permanent_forward_single_valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = permanent_forward_single_valid.json; path = ../../../../Desktop/permanent_forward_single_valid.json; sourceTree = "<group>"; };
+		079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchForwardGeocodingTests.swift; sourceTree = "<group>"; };
 		35506B8A200F856400629509 /* BridgingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BridgingTests.m; sourceTree = "<group>"; };
 		357B4357202CC90A00735521 /* reverse_address.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reverse_address.json; sourceTree = "<group>"; };
 		DA1AC0211E5C23B8006DF1D6 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
@@ -402,6 +410,7 @@
 		DDF1E84B1BD6F7BA00C40C78 /* MapboxGeocoderTests */ = {
 			isa = PBXGroup;
 			children = (
+				079F41E720E42EEF007EEB5E /* BatchForwardGeocodingTests.swift */,
 				DA701C001CB1292C00B0E520 /* GeocoderTests.swift */,
 				DA210BAA1CB4BE73008088FD /* ForwardGeocodingTests.swift */,
 				DDF1E84C1BD6F7BA00C40C78 /* ReverseGeocodingTests.swift */,
@@ -416,6 +425,7 @@
 		DDF1E8571BD700EB00C40C78 /* Fixtures */ = {
 			isa = PBXGroup;
 			children = (
+				079F41E320E42D7F007EEB5E /* permanent_forward_single_valid.json */,
 				DA210BAC1CB4BFF7008088FD /* forward_valid.json */,
 				DA58D8A01DB2ADDD00530CBB /* forward_valid_zh.json */,
 				DA210BAE1CB4C5A7008088FD /* forward_invalid.json */,
@@ -731,6 +741,7 @@
 				DA5170B91CF1B1F900CD6DCF /* forward_invalid.json in Resources */,
 				DA5170BB1CF1B1F900CD6DCF /* reverse_invalid.json in Resources */,
 				DA5170BA1CF1B1F900CD6DCF /* reverse_valid.json in Resources */,
+				079F41E520E42D7F007EEB5E /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A21DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -751,6 +762,7 @@
 				DA5170E31CF2542B00CD6DCF /* forward_invalid.json in Resources */,
 				DA5170E51CF2542B00CD6DCF /* reverse_invalid.json in Resources */,
 				DA5170E41CF2542B00CD6DCF /* reverse_valid.json in Resources */,
+				079F41E620E42D7F007EEB5E /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A31DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -794,6 +806,7 @@
 				DDF1E85C1BD70E4C00C40C78 /* reverse_invalid.json in Resources */,
 				DDF1E85D1BD70E4C00C40C78 /* reverse_valid.json in Resources */,
 				DA210BAF1CB4C5A7008088FD /* forward_invalid.json in Resources */,
+				079F41E420E42D7F007EEB5E /* permanent_forward_single_valid.json in Resources */,
 				DA58D8A11DB2ADDD00530CBB /* forward_valid_zh.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -885,6 +898,7 @@
 				DA5170B61CF1B1EF00CD6DCF /* ReverseGeocodingTests.swift in Sources */,
 				DA4D90081DD63AEC006EC71A /* PlacemarkScopeTests.swift in Sources */,
 				DA5170B41CF1B1EF00CD6DCF /* GeocoderTests.swift in Sources */,
+				079F41E920E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */,
 				DA5170B51CF1B1EF00CD6DCF /* ForwardGeocodingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -909,6 +923,7 @@
 				DA5170E11CF2542800CD6DCF /* ReverseGeocodingTests.swift in Sources */,
 				DA4D90091DD63AEC006EC71A /* PlacemarkScopeTests.swift in Sources */,
 				DA5170DF1CF2542800CD6DCF /* GeocoderTests.swift in Sources */,
+				079F41EA20E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */,
 				DA5170E01CF2542800CD6DCF /* ForwardGeocodingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -964,6 +979,7 @@
 				DDF1E84D1BD6F7BA00C40C78 /* ReverseGeocodingTests.swift in Sources */,
 				DA4D90071DD63AEC006EC71A /* PlacemarkScopeTests.swift in Sources */,
 				DA210BAB1CB4BE73008088FD /* ForwardGeocodingTests.swift in Sources */,
+				079F41E820E42EEF007EEB5E /* BatchForwardGeocodingTests.swift in Sources */,
 				DA701C011CB1292C00B0E520 /* GeocoderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MapboxGeocoder/MBGeocodeOptions.swift
+++ b/MapboxGeocoder/MBGeocodeOptions.swift
@@ -83,7 +83,7 @@ open class GeocodeOptions: NSObject {
     /**
      The query mode of the forward or reverse geocoding request.
     */
-    internal var mode: String = "mapbox.places"
+    internal var mode = "mapbox.places"
     
     /**
      An array of URL parameters to include in the request URL.

--- a/MapboxGeocoder/MBGeocodeOptions.swift
+++ b/MapboxGeocoder/MBGeocodeOptions.swift
@@ -81,6 +81,11 @@ open class GeocodeOptions: NSObject {
     internal var queries: [String] = []
     
     /**
+     The query mode of the forward or reverse geocoding request.
+    */
+    internal var mode: String = "mapbox.places"
+    
+    /**
      An array of URL parameters to include in the request URL.
      */
     internal var params: [URLQueryItem] {
@@ -222,6 +227,8 @@ open class ForwardBatchGeocodeOptions: ForwardGeocodeOptions, BatchGeocodeOption
     @objc public override init(queries: [String]) {
         super.init(queries: queries)
     }
+    
+    override internal var mode: String = "mapbox.places-permanent"
 }
 
 /**
@@ -246,4 +253,6 @@ open class ReverseBatchGeocodeOptions: ReverseGeocodeOptions, BatchGeocodeOption
     @objc public convenience init(locations: [CLLocation]) {
         self.init(coordinates: locations.map { $0.coordinate })
     }
+    
+    override internal var mode: String = "mapbox.places-permanent"
 }

--- a/MapboxGeocoder/MBGeocodeOptions.swift
+++ b/MapboxGeocoder/MBGeocodeOptions.swift
@@ -226,9 +226,8 @@ open class ForwardBatchGeocodeOptions: ForwardGeocodeOptions, BatchGeocodeOption
      */
     @objc public override init(queries: [String]) {
         super.init(queries: queries)
+        mode = "mapbox.places-permanent"
     }
-    
-    override internal var mode: String = "mapbox.places-permanent"
 }
 
 /**
@@ -243,6 +242,7 @@ open class ReverseBatchGeocodeOptions: ReverseGeocodeOptions, BatchGeocodeOption
      */
     @objc public override init(coordinates: [CLLocationCoordinate2D]) {
         super.init(coordinates: coordinates)
+        mode = "mapbox.places-permanent"
     }
     
     /**
@@ -252,7 +252,6 @@ open class ReverseBatchGeocodeOptions: ReverseGeocodeOptions, BatchGeocodeOption
      */
     @objc public convenience init(locations: [CLLocation]) {
         self.init(coordinates: locations.map { $0.coordinate })
+        mode = "mapbox.places-permanent"
     }
-    
-    override internal var mode: String = "mapbox.places-permanent"
 }

--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -290,13 +290,9 @@ open class Geocoder: NSObject {
         
         assert(!options.queries.isEmpty, "No query")
         
-        let mode: String
-        if options.queries.count > 1 {
-            mode = "mapbox.places-permanent"
-            assert(options.queries.count <= 50, "Too many queries in a single request.")
-        } else {
-            mode = "mapbox.places"
-        }
+        let mode = options.mode
+        
+        assert(options.queries.count <= 50, "Too many queries in a single request.")
         
         let queryComponent = options.queries.map {
             $0.replacingOccurrences(of: " ", with: "+")

--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -223,7 +223,9 @@ open class Geocoder: NSObject {
             let decoder = JSONDecoder()
             
             do {
+                
                 let result: [GeocodeResult]
+                
                 do {
                     // Decode multiple batch geocoding queries
                     result = try decoder.decode([GeocodeResult].self, from: data)
@@ -241,8 +243,6 @@ open class Geocoder: NSObject {
             }
             
         }) { (error) in
-            // testInvalidForwardSingleBatchGeocode fails here
-            // testInvalidForwardMultipleBatchGeocode fails here
             completionHandler(nil, nil, error)
         }
         task.resume()
@@ -260,6 +260,7 @@ open class Geocoder: NSObject {
      */
     fileprivate func dataTaskWithURL(_ url: URL, completionHandler: @escaping (_ data: Data?) -> Void, errorHandler: @escaping (_ error: NSError) -> Void) -> URLSessionDataTask {
         var request = URLRequest(url: url)
+        
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         return URLSession.shared.dataTask(with: request) { (data, response, error) in
 
@@ -286,7 +287,6 @@ open class Geocoder: NSObject {
                 do {
                     let result = try decoder.decode(GeocodeAPIResult.self, from: data)
                     // Check if geocoding query failed
-                        // testInvalidForwardSingleBatchGeocode & testInvalidForwardMultipleBatchGeocode being caught here
                     guard result.message == nil else {
                         let apiError = Geocoder.descriptiveError(["message": result.message!], response: response, underlyingError: error as NSError?)
                         DispatchQueue.main.async {

--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -320,8 +320,6 @@ open class Geocoder: NSObject {
         
         let mode = options.mode
         
-        assert(options.queries.count <= 50, "Too many queries in a single request.")
-        
         let queryComponent = options.queries.map {
             $0.replacingOccurrences(of: " ", with: "+")
                 .addingPercentEncoding(withAllowedCharacters: CharacterSet.geocodingQueryAllowedCharacterSet()) ?? ""

--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -241,6 +241,8 @@ open class Geocoder: NSObject {
             }
             
         }) { (error) in
+            // testInvalidForwardSingleBatchGeocode fails here
+            // testInvalidForwardMultipleBatchGeocode fails here
             completionHandler(nil, nil, error)
         }
         task.resume()
@@ -284,6 +286,7 @@ open class Geocoder: NSObject {
                 do {
                     let result = try decoder.decode(GeocodeAPIResult.self, from: data)
                     // Check if geocoding query failed
+                        // testInvalidForwardSingleBatchGeocode & testInvalidForwardMultipleBatchGeocode being caught here
                     guard result.message == nil else {
                         let apiError = Geocoder.descriptiveError(["message": result.message!], response: response, underlyingError: error as NSError?)
                         DispatchQueue.main.async {

--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -287,12 +287,13 @@ open class Geocoder: NSObject {
                 do {
                     let result = try decoder.decode(GeocodeAPIResult.self, from: data)
                     // Check if geocoding query failed
-                    guard result.message == nil else {
-                        let apiError = Geocoder.descriptiveError(["message": result.message!], response: response, underlyingError: error as NSError?)
+                    if let message = result.message {
+                        let apiError = Geocoder.descriptiveError(["message": message], response: response, underlyingError: error as NSError?)
                         DispatchQueue.main.async {
                             errorHandler(apiError)
                         }
                         return
+                        
                     }
                     DispatchQueue.main.async {
                         completionHandler(data)

--- a/MapboxGeocoderTests/BatchForwardGeocodingTests.swift
+++ b/MapboxGeocoderTests/BatchForwardGeocodingTests.swift
@@ -9,8 +9,8 @@ class BatchForwardGeocodingTests: XCTestCase {
         super.tearDown()
     }
     
-    func testValidForwardGeocode() {
-        let expectation = self.expectation(description: "forward batch geocode should return results")
+    func testValidForwardSingleBatchGeocode() {
+        let expectation = self.expectation(description: "forward batch geocode with single query should return results")
         
         _ = stub(condition: isHost("api.mapbox.com")
             && isPath("/geocoding/v5/mapbox.places-permanent/85+2nd+st+san+francisco.json")
@@ -28,10 +28,51 @@ class BatchForwardGeocodingTests: XCTestCase {
             let results = placemarks![0]
             let attribution = attribution![0]
         
-            XCTAssertEqual(results.count, 5, "forward batch geocode should have 5 results")
+            XCTAssertEqual(results.count, 5, "single forward batch geocode should have 5 results")
             
-            XCTAssertEqual(attribution, "NOTICE: © 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https://www.mapbox.com/about/maps/). This response and the information it contains may not be retained.")
+            XCTAssertEqual(attribution, "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)")
             
+            expectation.fulfill()
+        }
+        XCTAssertNotNil(task)
+        
+        waitForExpectations(timeout: 1) { (error) in
+            XCTAssertNil(error, "Error: \(error!)")
+            XCTAssertEqual(task.state, URLSessionTask.State.completed)
+        }
+    }
+    
+    func testValidForwardMultipleBatchGeocode() {
+        let expectation = self.expectation(description: "forward batch geocode with multiple queries should return results")
+        
+        _ = stub(condition: isHost("api.mapbox.com")
+            && isPath("/geocoding/v5/mapbox.places-permanent/20001;20001;20001.json")
+            && containsQueryParams(["country": "us", "access_token": BogusToken])) { _ in
+                let path = Bundle(for: type(of: self)).path(forResource: "permanent_forward_multiple_valid", ofType: "json")
+                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
+        }
+        
+        let geocoder = Geocoder(accessToken: BogusToken)
+        
+        let options = ForwardBatchGeocodeOptions(queries: ["20001", "20001", "20001"])
+        options.allowedISOCountryCodes = ["US"]
+        
+        let task = geocoder.batchGeocode(options) { (placemarks, attribution, error) in
+            
+            let queries = placemarks!
+            let attribution = attribution![0]
+            
+            XCTAssertEqual(queries.count, 3, "forward batch geocode should have 3 queries")
+            
+            for result in queries {
+                XCTAssertEqual(result.count, 5, "each forward batch geocode query should have 5 found results")
+                XCTAssertEqual(attribution, "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)")
+            }
+            
+            let sampleResult = queries[0][0]
+            
+            XCTAssertEqual(sampleResult.qualifiedName, "Washington, District of Columbia 20001, United States")
+
             expectation.fulfill()
         }
         XCTAssertNotNil(task)

--- a/MapboxGeocoderTests/BatchForwardGeocodingTests.swift
+++ b/MapboxGeocoderTests/BatchForwardGeocodingTests.swift
@@ -112,4 +112,34 @@ class BatchForwardGeocodingTests: XCTestCase {
             XCTAssertEqual(task.state, URLSessionTask.State.completed)
         }
     }
+    
+    func testInvalidForwardMultipleBatchGeocode() {
+        _ = stub(condition: isHost("api.mapbox.com")
+            && isPath("/geocoding/v5/mapbox.places-permanent/%23M%40Pb0X%3B%20%24C00L!.json")
+            && containsQueryParams(["access_token": BogusToken])) { _ in
+                let path = Bundle(for: type(of: self)).path(forResource: "permanent_forward_multiple_invalid", ofType: "json")
+                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
+        }
+        
+        let expectation = self.expectation(description: "multiple forward batch geocode execute completion handler for invalid query")
+        let geocoder = Geocoder(accessToken: BogusToken)
+        let options = ForwardBatchGeocodeOptions(queries: ["#M@Pb0X", "$C00L!"])
+        let task = geocoder.batchGeocode(options) { (placemarks, attribution, error) in
+            
+            //            let results = placemarks![0]
+            //            let attribution = attribution![0]
+            //
+            //            XCTAssertEqual(results.count, 0, "multiple forward batch geocode should return no results for invalid query")
+            //
+            //            XCTAssertEqual(attribution, "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/")
+            
+            expectation.fulfill()
+        }
+        XCTAssertNotNil(task)
+        
+        waitForExpectations(timeout: 1) { (error) in
+            XCTAssertNil(error, "Error: \(error!)")
+            XCTAssertEqual(task.state, URLSessionTask.State.completed)
+        }
+    }
 }

--- a/MapboxGeocoderTests/BatchForwardGeocodingTests.swift
+++ b/MapboxGeocoderTests/BatchForwardGeocodingTests.swift
@@ -83,25 +83,24 @@ class BatchForwardGeocodingTests: XCTestCase {
         }
     }
     
-    func testInvalidForwardSingleBatchGeocode() {
+    func testNoResultsForwardSingleBatchGeocode() {
         _ = stub(condition: isHost("api.mapbox.com")
-            && isPath("/geocoding/v5/mapbox.places-permanent/%23M%40Pb0X.json")
+            && isPath("/geocoding/v5/mapbox.places-permanent/#M@Pb0X.json") // Text does not need to be encoded
             && containsQueryParams(["access_token": BogusToken])) { _ in
-                let path = Bundle(for: type(of: self)).path(forResource: "permanent_forward_single_invalid", ofType: "json")
+                let path = Bundle(for: type(of: self)).path(forResource: "permanent_forward_single_no_results", ofType: "json")
                 return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
         }
         
-        let expectation = self.expectation(description: "single forward batch geocode execute completion handler for invalid query")
+        let expectation = self.expectation(description: "single forward batch geocode should not return results for an invalid location")
         let geocoder = Geocoder(accessToken: BogusToken)
         let options = ForwardBatchGeocodeOptions(query: "#M@Pb0X")
         let task = geocoder.batchGeocode(options) { (placemarks, attribution, error) in
             
-//            let results = placemarks![0]
-//            let attribution = attribution![0]
-//
-//            XCTAssertEqual(results.count, 0, "single forward batch geocode should return no results for invalid query")
-//
-//            XCTAssertEqual(attribution, "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/")
+            let results = placemarks![0]
+            let attribution = attribution![0]
+
+            XCTAssertEqual(results.count, 0, "single forward batch geocode should not return results for an invalid location")
+            XCTAssertEqual(attribution, "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)")
             
             expectation.fulfill()
         }
@@ -113,25 +112,24 @@ class BatchForwardGeocodingTests: XCTestCase {
         }
     }
     
-    func testInvalidForwardMultipleBatchGeocode() {
+    func testNoResultsForwardMultipleBatchGeocode() {
         _ = stub(condition: isHost("api.mapbox.com")
-            && isPath("/geocoding/v5/mapbox.places-permanent/%23M%40Pb0X%3B%20%24C00L!.json")
+            && isPath("/geocoding/v5/mapbox.places-permanent/#M@Pb0X;$C00L!.json")
             && containsQueryParams(["access_token": BogusToken])) { _ in
-                let path = Bundle(for: type(of: self)).path(forResource: "permanent_forward_multiple_invalid", ofType: "json")
+                let path = Bundle(for: type(of: self)).path(forResource: "permanent_forward_multiple_no_results", ofType: "json")
                 return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
         }
         
-        let expectation = self.expectation(description: "multiple forward batch geocode execute completion handler for invalid query")
+        let expectation = self.expectation(description: "multiple forward batch geocode should not return results for an invalid locations")
         let geocoder = Geocoder(accessToken: BogusToken)
         let options = ForwardBatchGeocodeOptions(queries: ["#M@Pb0X", "$C00L!"])
         let task = geocoder.batchGeocode(options) { (placemarks, attribution, error) in
             
-            //            let results = placemarks![0]
-            //            let attribution = attribution![0]
-            //
-            //            XCTAssertEqual(results.count, 0, "multiple forward batch geocode should return no results for invalid query")
-            //
-            //            XCTAssertEqual(attribution, "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/")
+            for result in placemarks! {
+                XCTAssertTrue(result.isEmpty, "each individual geocode request should not return results")
+            }
+            
+          XCTAssertEqual(attribution![0], "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)")
             
             expectation.fulfill()
         }

--- a/MapboxGeocoderTests/BatchForwardGeocodingTests.swift
+++ b/MapboxGeocoderTests/BatchForwardGeocodingTests.swift
@@ -82,4 +82,34 @@ class BatchForwardGeocodingTests: XCTestCase {
             XCTAssertEqual(task.state, URLSessionTask.State.completed)
         }
     }
+    
+    func testInvalidForwardSingleBatchGeocode() {
+        _ = stub(condition: isHost("api.mapbox.com")
+            && isPath("/geocoding/v5/mapbox.places-permanent/%23M%40Pb0X.json")
+            && containsQueryParams(["access_token": BogusToken])) { _ in
+                let path = Bundle(for: type(of: self)).path(forResource: "permanent_forward_single_invalid", ofType: "json")
+                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
+        }
+        
+        let expectation = self.expectation(description: "single forward batch geocode execute completion handler for invalid query")
+        let geocoder = Geocoder(accessToken: BogusToken)
+        let options = ForwardBatchGeocodeOptions(query: "#M@Pb0X")
+        let task = geocoder.batchGeocode(options) { (placemarks, attribution, error) in
+            
+//            let results = placemarks![0]
+//            let attribution = attribution![0]
+//
+//            XCTAssertEqual(results.count, 0, "single forward batch geocode should return no results for invalid query")
+//
+//            XCTAssertEqual(attribution, "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/")
+            
+            expectation.fulfill()
+        }
+        XCTAssertNotNil(task)
+        
+        waitForExpectations(timeout: 1) { (error) in
+            XCTAssertNil(error, "Error: \(error!)")
+            XCTAssertEqual(task.state, URLSessionTask.State.completed)
+        }
+    }
 }

--- a/MapboxGeocoderTests/BatchForwardGeocodingTests.swift
+++ b/MapboxGeocoderTests/BatchForwardGeocodingTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import OHHTTPStubs
+import CoreLocation
+@testable import MapboxGeocoder
+
+class BatchForwardGeocodingTests: XCTestCase {
+    override func tearDown() {
+        OHHTTPStubs.removeAllStubs()
+        super.tearDown()
+    }
+    
+    func testValidForwardGeocode() {
+        let expectation = self.expectation(description: "forward batch geocode should return results")
+        
+        _ = stub(condition: isHost("api.mapbox.com")
+            && isPath("/geocoding/v5/mapbox.places-permanent/85+2nd+st+san+francisco.json")
+            && containsQueryParams(["country": "ca", "access_token": BogusToken])) { _ in
+                let path = Bundle(for: type(of: self)).path(forResource: "permanent_forward_single_valid", ofType: "json")
+                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
+        }
+        
+        let geocoder = Geocoder(accessToken: BogusToken)
+
+        let options = ForwardBatchGeocodeOptions(query: "85 2nd st san francisco")
+        options.allowedISOCountryCodes = ["CA"]
+
+        let task = geocoder.batchGeocode(options) { (placemarks, attribution, error) in
+            let results = placemarks![0]
+            let attribution = attribution![0]
+        
+            XCTAssertEqual(results.count, 5, "forward batch geocode should have 5 results")
+            
+            XCTAssertEqual(attribution, "NOTICE: © 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https://www.mapbox.com/about/maps/). This response and the information it contains may not be retained.")
+            
+            expectation.fulfill()
+        }
+        XCTAssertNotNil(task)
+        
+        waitForExpectations(timeout: 1) { (error) in
+            XCTAssertNil(error, "Error: \(error!)")
+            XCTAssertEqual(task.state, URLSessionTask.State.completed)
+        }
+    }
+}

--- a/MapboxGeocoderTests/BatchGeocodingTests.swift
+++ b/MapboxGeocoderTests/BatchGeocodingTests.swift
@@ -230,8 +230,7 @@ class BatchGeocodingTests: XCTestCase {
     func testNoResultsReverseSingleBatchGeocode() {
         _ = stub(condition: isHost("api.mapbox.com")
             
-           // && isPath("/geocoding/v5/mapbox.places-permanent/100,100.json")
-              // The above line is causing the test fo fail for unknown reasons
+            && isPath("/geocoding/v5/mapbox.places-permanent/100.00000,100.00000.json")
             && containsQueryParams(["access_token": BogusToken])) { _ in
                 let path = Bundle(for: type(of: self)).path(forResource: "permanent_reverse_single_no_results", ofType: "json")
                 return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
@@ -262,8 +261,7 @@ class BatchGeocodingTests: XCTestCase {
         let expectation = self.expectation(description: "multiple reverse batch geocodes should not return results for invalid locations")
         
         _ = stub(condition: isHost("api.mapbox.com")
-         // && isPath("/geocoding/v5/mapbox.places-permanent/100,100.json")
-         // The above line is causing the test fo fail for unknown reasons
+            && isPath("/geocoding/v5/mapbox.places-permanent/100.00000,100.00000;100.00000,100.00000;100.00000,100.00000.json")
             && containsQueryParams(["access_token": BogusToken])) { _ in
                 let path = Bundle(for: type(of: self)).path(forResource: "permanent_reverse_multiple_no_results", ofType: "json")
                 return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])

--- a/MapboxGeocoderTests/BatchGeocodingTests.swift
+++ b/MapboxGeocoderTests/BatchGeocodingTests.swift
@@ -146,6 +146,162 @@ class BatchGeocodingTests: XCTestCase {
     }
     
     /**
+     Reverse batch geocoding tests
+     */
+    
+    func testValidReverseSingleBatchGeocode() {
+        let expectation = self.expectation(description: "reverse batch geocode with single query should return results")
+        
+        _ = stub(condition: isHost("api.mapbox.com")
+            && isPath("/geocoding/v5/mapbox.places-permanent/-77.01073,38.88887.json")
+            && containsQueryParams(["access_token": BogusToken])) { _ in
+                let path = Bundle(for: type(of: self)).path(forResource: "permanent_reverse_single_valid", ofType: "json")
+                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
+        }
+        
+        let geocoder = Geocoder(accessToken: BogusToken)
+        
+        let options = ReverseBatchGeocodeOptions(coordinate: CLLocationCoordinate2DMake(38.88887, -77.01073))
+        
+        let task = geocoder.batchGeocode(options) { (placemarks, attribution, error) in
+            let results = placemarks![0]
+            let attribution = attribution![0]
+            
+            XCTAssertEqual(results.count, 6, "single forward batch geocode should have 6 results")
+            
+            XCTAssertEqual(attribution, "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)")
+            
+            expectation.fulfill()
+        }
+        XCTAssertNotNil(task)
+        
+        waitForExpectations(timeout: 1) { (error) in
+            XCTAssertNil(error, "Error: \(error!)")
+            XCTAssertEqual(task.state, URLSessionTask.State.completed)
+        }
+    }
+    
+    func testValidReverseMultipleBatchGeocode() {
+        let expectation = self.expectation(description: "forward batch geocode with multiple queries should return results")
+        
+        _ = stub(condition: isHost("api.mapbox.com")
+            && isPath("/geocoding/v5/mapbox.places-permanent/-77.01073,38.88887;-77.01073,38.88887;-77.01073,38.88887.json")
+            && containsQueryParams(["access_token": BogusToken])) { _ in
+                let path = Bundle(for: type(of: self)).path(forResource: "permanent_reverse_multiple_valid", ofType: "json")
+                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
+        }
+        
+        let geocoder = Geocoder(accessToken: BogusToken)
+        
+        let queries = [
+            CLLocationCoordinate2DMake(38.88887, -77.01073),
+            CLLocationCoordinate2DMake(38.88887, -77.01073),
+            CLLocationCoordinate2DMake(38.88887, -77.01073)
+        ]
+        
+        let options = ReverseBatchGeocodeOptions(coordinates: queries)
+
+        let task = geocoder.batchGeocode(options) { (placemarks, attribution, error) in
+            
+            let queries = placemarks!
+            let attribution = attribution![0]
+            
+            XCTAssertEqual(queries.count, 3, "forward batch geocode should have 3 queries")
+            
+            for result in queries {
+                XCTAssertEqual(result.count, 6, "each forward batch geocode query should have 6 found results")
+                XCTAssertEqual(attribution, "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)")
+            }
+            
+            let sampleResult = queries[0][0]
+            
+            XCTAssertEqual(sampleResult.qualifiedName, "South Capitol Circle Southwest, Washington, District of Columbia 20002, United States")
+            
+            expectation.fulfill()
+        }
+        XCTAssertNotNil(task)
+        
+        waitForExpectations(timeout: 1) { (error) in
+            XCTAssertNil(error, "Error: \(error!)")
+            XCTAssertEqual(task.state, URLSessionTask.State.completed)
+        }
+    }
+    
+    func testNoResultsReverseSingleBatchGeocode() {
+        _ = stub(condition: isHost("api.mapbox.com")
+            
+           // && isPath("/geocoding/v5/mapbox.places-permanent/100,100.json")
+              // The above line is causing the test fo fail for unknown reasons
+            && containsQueryParams(["access_token": BogusToken])) { _ in
+                let path = Bundle(for: type(of: self)).path(forResource: "permanent_reverse_single_no_results", ofType: "json")
+                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
+        }
+        
+        let expectation = self.expectation(description: "single reverse batch geocode should not return results for an invalid location")
+        let geocoder = Geocoder(accessToken: BogusToken)
+        let options = ReverseBatchGeocodeOptions(coordinate: CLLocationCoordinate2DMake(100, 100))
+        let task = geocoder.batchGeocode(options) { (placemarks, attribution, error) in
+            
+            let results = placemarks![0]
+            let attribution = attribution![0]
+            
+            XCTAssertEqual(results.count, 0, "single reverse batch geocode should not return results for an invalid location")
+            XCTAssertEqual(attribution, "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)")
+            
+            expectation.fulfill()
+        }
+        XCTAssertNotNil(task)
+        
+        waitForExpectations(timeout: 1) { (error) in
+            XCTAssertNil(error, "Error: \(error!)")
+            XCTAssertEqual(task.state, URLSessionTask.State.completed)
+        }
+    }
+    
+    func testNoResultsReverseMultipleBatchGeocode() {
+        let expectation = self.expectation(description: "multiple reverse batch geocodes should not return results for invalid locations")
+        
+        _ = stub(condition: isHost("api.mapbox.com")
+         // && isPath("/geocoding/v5/mapbox.places-permanent/100,100.json")
+         // The above line is causing the test fo fail for unknown reasons
+            && containsQueryParams(["access_token": BogusToken])) { _ in
+                let path = Bundle(for: type(of: self)).path(forResource: "permanent_reverse_multiple_no_results", ofType: "json")
+                return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/vnd.geo+json"])
+        }
+        
+        let geocoder = Geocoder(accessToken: BogusToken)
+        
+        let queries = [
+            CLLocationCoordinate2DMake(100, 100),
+            CLLocationCoordinate2DMake(100, 100),
+            CLLocationCoordinate2DMake(100, 100)
+        ]
+        
+        let options = ReverseBatchGeocodeOptions(coordinates: queries)
+        
+        let task = geocoder.batchGeocode(options) { (placemarks, attribution, error) in
+            
+            let queries = placemarks!
+            let attribution = attribution![0]
+            
+            XCTAssertEqual(queries.count, 3, "reverse batch geocode should have 3 queries")
+            
+            for result in queries {
+                XCTAssertEqual(result.count, 0, "each reverse batch geocode query should have 0 found results")
+                XCTAssertEqual(attribution, "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)")
+            }
+            
+            expectation.fulfill()
+        }
+        XCTAssertNotNil(task)
+        
+        waitForExpectations(timeout: 1) { (error) in
+            XCTAssertNil(error, "Error: \(error!)")
+            XCTAssertEqual(task.state, URLSessionTask.State.completed)
+        }
+    }
+    
+    /**
      General batch geocoding tests - invalid queries, invalid tokens, token scope checking, etc.
      */
     

--- a/MapboxGeocoderTests/fixtures/permanent_forward_multiple_no_results.json
+++ b/MapboxGeocoderTests/fixtures/permanent_forward_multiple_no_results.json
@@ -1,0 +1,23 @@
+[
+  {
+    "type": "FeatureCollection",
+    "query": [
+      "m",
+      "pb0x"
+    ],
+    "features": [
+      
+    ],
+    "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+  },
+  {
+    "type": "FeatureCollection",
+    "query": [
+      "c00l"
+    ],
+    "features": [
+      
+    ],
+    "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+  }
+]

--- a/MapboxGeocoderTests/fixtures/permanent_forward_multiple_valid.json
+++ b/MapboxGeocoderTests/fixtures/permanent_forward_multiple_valid.json
@@ -1,0 +1,716 @@
+[
+  {
+    "type": "FeatureCollection",
+    "query": [
+      "20001"
+    ],
+    "features": [
+      {
+        "id": "postcode.17502531659389280",
+        "type": "Feature",
+        "place_type": [
+          "postcode"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001",
+        "place_name": "Washington, District of Columbia 20001, United States",
+        "bbox": [
+          -77.0282940080508,
+          38.890665010602,
+          -77.0071750094517,
+          38.9292809921057
+        ],
+        "center": [
+          -77.02,
+          38.9
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.02,
+            38.9
+          ]
+        },
+        "context": [
+          {
+            "id": "place.7673410831246050",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "short_code": "us",
+            "wikidata": "Q30",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "postcode.14626046980389280",
+        "type": "Feature",
+        "place_type": [
+          "postcode"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001",
+        "place_name": "20001, Donostia, Gipuzkoa, Spain",
+        "bbox": [
+          -1.977172,
+          43.320914,
+          -1.969088,
+          43.326066
+        ],
+        "center": [
+          -1.972363,
+          43.323461
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -1.972363,
+            43.323461
+          ]
+        },
+        "context": [
+          {
+            "id": "place.17550260039396600",
+            "wikidata": "Q10313",
+            "text": "Donostia"
+          },
+          {
+            "id": "region.225124",
+            "short_code": "ES-SS",
+            "wikidata": "Q95010",
+            "text": "Gipuzkoa"
+          },
+          {
+            "id": "country.3110",
+            "short_code": "es",
+            "wikidata": "Q29",
+            "text": "Spain"
+          }
+        ]
+      },
+      {
+        "id": "address.6162352618677344",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001 Westside Dr",
+        "place_name": "20001 Westside Dr, Frankford, Missouri 63441, United States",
+        "center": [
+          -91.36103,
+          39.533667
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -91.36103,
+            39.533667
+          ]
+        },
+        "context": [
+          {
+            "id": "postcode.7586275482125420",
+            "text": "63441"
+          },
+          {
+            "id": "place.16531927802291200",
+            "wikidata": "Q960791",
+            "text": "Frankford"
+          },
+          {
+            "id": "region.28004",
+            "short_code": "US-MO",
+            "wikidata": "Q1581",
+            "text": "Missouri"
+          },
+          {
+            "id": "country.3145",
+            "short_code": "us",
+            "wikidata": "Q30",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "address.3374631738293172",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001 Painted Cup Dr",
+        "place_name": "20001 Painted Cup Dr, Unionville, Missouri 63565, United States",
+        "center": [
+          -93.01847,
+          40.511112
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -93.01847,
+            40.511112
+          ]
+        },
+        "context": [
+          {
+            "id": "postcode.13217932637767190",
+            "text": "63565"
+          },
+          {
+            "id": "place.10055886748333240",
+            "wikidata": "Q598853",
+            "text": "Unionville"
+          },
+          {
+            "id": "region.28004",
+            "short_code": "US-MO",
+            "wikidata": "Q1581",
+            "text": "Missouri"
+          },
+          {
+            "id": "country.3145",
+            "short_code": "us",
+            "wikidata": "Q30",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "address.1212803431057912",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001",
+        "place_name": "20001, Mc Alpin, Florida 32062, United States",
+        "center": [
+          -82.94874,
+          30.085461
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.94874,
+            30.085461
+          ]
+        },
+        "context": [
+          {
+            "id": "postcode.6857120106983010",
+            "text": "32062"
+          },
+          {
+            "id": "place.4536624049214180",
+            "wikidata": null,
+            "text": "Mc Alpin"
+          },
+          {
+            "id": "region.3865",
+            "short_code": "US-FL",
+            "wikidata": "Q812",
+            "text": "Florida"
+          },
+          {
+            "id": "country.3145",
+            "short_code": "us",
+            "wikidata": "Q30",
+            "text": "United States"
+          }
+        ]
+      }
+    ],
+    "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+  },
+  {
+    "type": "FeatureCollection",
+    "query": [
+      "20001"
+    ],
+    "features": [
+      {
+        "id": "postcode.17502531659389280",
+        "type": "Feature",
+        "place_type": [
+          "postcode"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001",
+        "place_name": "Washington, District of Columbia 20001, United States",
+        "bbox": [
+          -77.0282940080508,
+          38.890665010602,
+          -77.0071750094517,
+          38.9292809921057
+        ],
+        "center": [
+          -77.02,
+          38.9
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.02,
+            38.9
+          ]
+        },
+        "context": [
+          {
+            "id": "place.7673410831246050",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "short_code": "us",
+            "wikidata": "Q30",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "postcode.14626046980389280",
+        "type": "Feature",
+        "place_type": [
+          "postcode"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001",
+        "place_name": "20001, Donostia, Gipuzkoa, Spain",
+        "bbox": [
+          -1.977172,
+          43.320914,
+          -1.969088,
+          43.326066
+        ],
+        "center": [
+          -1.972363,
+          43.323461
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -1.972363,
+            43.323461
+          ]
+        },
+        "context": [
+          {
+            "id": "place.17550260039396600",
+            "wikidata": "Q10313",
+            "text": "Donostia"
+          },
+          {
+            "id": "region.225124",
+            "short_code": "ES-SS",
+            "wikidata": "Q95010",
+            "text": "Gipuzkoa"
+          },
+          {
+            "id": "country.3110",
+            "short_code": "es",
+            "wikidata": "Q29",
+            "text": "Spain"
+          }
+        ]
+      },
+      {
+        "id": "address.6162352618677344",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001 Westside Dr",
+        "place_name": "20001 Westside Dr, Frankford, Missouri 63441, United States",
+        "center": [
+          -91.36103,
+          39.533667
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -91.36103,
+            39.533667
+          ]
+        },
+        "context": [
+          {
+            "id": "postcode.7586275482125420",
+            "text": "63441"
+          },
+          {
+            "id": "place.16531927802291200",
+            "wikidata": "Q960791",
+            "text": "Frankford"
+          },
+          {
+            "id": "region.28004",
+            "short_code": "US-MO",
+            "wikidata": "Q1581",
+            "text": "Missouri"
+          },
+          {
+            "id": "country.3145",
+            "short_code": "us",
+            "wikidata": "Q30",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "address.3374631738293172",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001 Painted Cup Dr",
+        "place_name": "20001 Painted Cup Dr, Unionville, Missouri 63565, United States",
+        "center": [
+          -93.01847,
+          40.511112
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -93.01847,
+            40.511112
+          ]
+        },
+        "context": [
+          {
+            "id": "postcode.13217932637767190",
+            "text": "63565"
+          },
+          {
+            "id": "place.10055886748333240",
+            "wikidata": "Q598853",
+            "text": "Unionville"
+          },
+          {
+            "id": "region.28004",
+            "short_code": "US-MO",
+            "wikidata": "Q1581",
+            "text": "Missouri"
+          },
+          {
+            "id": "country.3145",
+            "short_code": "us",
+            "wikidata": "Q30",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "address.1212803431057912",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001",
+        "place_name": "20001, Mc Alpin, Florida 32062, United States",
+        "center": [
+          -82.94874,
+          30.085461
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.94874,
+            30.085461
+          ]
+        },
+        "context": [
+          {
+            "id": "postcode.6857120106983010",
+            "text": "32062"
+          },
+          {
+            "id": "place.4536624049214180",
+            "wikidata": null,
+            "text": "Mc Alpin"
+          },
+          {
+            "id": "region.3865",
+            "short_code": "US-FL",
+            "wikidata": "Q812",
+            "text": "Florida"
+          },
+          {
+            "id": "country.3145",
+            "short_code": "us",
+            "wikidata": "Q30",
+            "text": "United States"
+          }
+        ]
+      }
+    ],
+    "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+  },
+  {
+    "type": "FeatureCollection",
+    "query": [
+      "20001"
+    ],
+    "features": [
+      {
+        "id": "postcode.17502531659389280",
+        "type": "Feature",
+        "place_type": [
+          "postcode"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001",
+        "place_name": "Washington, District of Columbia 20001, United States",
+        "bbox": [
+          -77.0282940080508,
+          38.890665010602,
+          -77.0071750094517,
+          38.9292809921057
+        ],
+        "center": [
+          -77.02,
+          38.9
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.02,
+            38.9
+          ]
+        },
+        "context": [
+          {
+            "id": "place.7673410831246050",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "short_code": "us",
+            "wikidata": "Q30",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "postcode.14626046980389280",
+        "type": "Feature",
+        "place_type": [
+          "postcode"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001",
+        "place_name": "20001, Donostia, Gipuzkoa, Spain",
+        "bbox": [
+          -1.977172,
+          43.320914,
+          -1.969088,
+          43.326066
+        ],
+        "center": [
+          -1.972363,
+          43.323461
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -1.972363,
+            43.323461
+          ]
+        },
+        "context": [
+          {
+            "id": "place.17550260039396600",
+            "wikidata": "Q10313",
+            "text": "Donostia"
+          },
+          {
+            "id": "region.225124",
+            "short_code": "ES-SS",
+            "wikidata": "Q95010",
+            "text": "Gipuzkoa"
+          },
+          {
+            "id": "country.3110",
+            "short_code": "es",
+            "wikidata": "Q29",
+            "text": "Spain"
+          }
+        ]
+      },
+      {
+        "id": "address.6162352618677344",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001 Westside Dr",
+        "place_name": "20001 Westside Dr, Frankford, Missouri 63441, United States",
+        "center": [
+          -91.36103,
+          39.533667
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -91.36103,
+            39.533667
+          ]
+        },
+        "context": [
+          {
+            "id": "postcode.7586275482125420",
+            "text": "63441"
+          },
+          {
+            "id": "place.16531927802291200",
+            "wikidata": "Q960791",
+            "text": "Frankford"
+          },
+          {
+            "id": "region.28004",
+            "short_code": "US-MO",
+            "wikidata": "Q1581",
+            "text": "Missouri"
+          },
+          {
+            "id": "country.3145",
+            "short_code": "us",
+            "wikidata": "Q30",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "address.3374631738293172",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001 Painted Cup Dr",
+        "place_name": "20001 Painted Cup Dr, Unionville, Missouri 63565, United States",
+        "center": [
+          -93.01847,
+          40.511112
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -93.01847,
+            40.511112
+          ]
+        },
+        "context": [
+          {
+            "id": "postcode.13217932637767190",
+            "text": "63565"
+          },
+          {
+            "id": "place.10055886748333240",
+            "wikidata": "Q598853",
+            "text": "Unionville"
+          },
+          {
+            "id": "region.28004",
+            "short_code": "US-MO",
+            "wikidata": "Q1581",
+            "text": "Missouri"
+          },
+          {
+            "id": "country.3145",
+            "short_code": "us",
+            "wikidata": "Q30",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "address.1212803431057912",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "relevance": 1,
+        "properties": {},
+        "text": "20001",
+        "place_name": "20001, Mc Alpin, Florida 32062, United States",
+        "center": [
+          -82.94874,
+          30.085461
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.94874,
+            30.085461
+          ]
+        },
+        "context": [
+          {
+            "id": "postcode.6857120106983010",
+            "text": "32062"
+          },
+          {
+            "id": "place.4536624049214180",
+            "wikidata": null,
+            "text": "Mc Alpin"
+          },
+          {
+            "id": "region.3865",
+            "short_code": "US-FL",
+            "wikidata": "Q812",
+            "text": "Florida"
+          },
+          {
+            "id": "country.3145",
+            "short_code": "us",
+            "wikidata": "Q30",
+            "text": "United States"
+          }
+        ]
+      }
+    ],
+    "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+  }
+]

--- a/MapboxGeocoderTests/fixtures/permanent_forward_multiple_valid.json
+++ b/MapboxGeocoderTests/fixtures/permanent_forward_multiple_valid.json
@@ -6,7 +6,7 @@
     ],
     "features": [
       {
-        "id": "postcode.17502531659389280",
+        "id": "postcode.123",
         "type": "Feature",
         "place_type": [
           "postcode"
@@ -16,36 +16,36 @@
         "text": "20001",
         "place_name": "Washington, District of Columbia 20001, United States",
         "bbox": [
-          -77.0282940080508,
-          38.890665010602,
-          -77.0071750094517,
-          38.9292809921057
+          -77,
+          38,
+          -77,
+          38
         ],
         "center": [
-          -77.02,
-          38.9
+          -77,
+          38
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -77.02,
-            38.9
+            -77,
+            38
           ]
         },
         "context": [
           {
-            "id": "place.7673410831246050",
+            "id": "place.123",
             "wikidata": "Q61",
             "text": "Washington"
           },
           {
-            "id": "region.3403",
+            "id": "region.123",
             "short_code": "US-DC",
             "wikidata": "Q61",
             "text": "District of Columbia"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "short_code": "us",
             "wikidata": "Q30",
             "text": "United States"
@@ -53,7 +53,7 @@
         ]
       },
       {
-        "id": "postcode.14626046980389280",
+        "id": "postcode.123",
         "type": "Feature",
         "place_type": [
           "postcode"
@@ -63,36 +63,36 @@
         "text": "20001",
         "place_name": "20001, Donostia, Gipuzkoa, Spain",
         "bbox": [
-          -1.977172,
-          43.320914,
-          -1.969088,
-          43.326066
+          -1,
+          43,
+          -1,
+          43
         ],
         "center": [
-          -1.972363,
-          43.323461
+          -1,
+          43
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -1.972363,
-            43.323461
+            -1,
+            43
           ]
         },
         "context": [
           {
-            "id": "place.17550260039396600",
+            "id": "place.123",
             "wikidata": "Q10313",
             "text": "Donostia"
           },
           {
-            "id": "region.225124",
+            "id": "region.123",
             "short_code": "ES-SS",
             "wikidata": "Q95010",
             "text": "Gipuzkoa"
           },
           {
-            "id": "country.3110",
+            "id": "country.123",
             "short_code": "es",
             "wikidata": "Q29",
             "text": "Spain"
@@ -100,7 +100,7 @@
         ]
       },
       {
-        "id": "address.6162352618677344",
+        "id": "address.123",
         "type": "Feature",
         "place_type": [
           "address"
@@ -110,34 +110,34 @@
         "text": "20001 Westside Dr",
         "place_name": "20001 Westside Dr, Frankford, Missouri 63441, United States",
         "center": [
-          -91.36103,
-          39.533667
+          -91,
+          39
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -91.36103,
-            39.533667
+            -91,
+            39
           ]
         },
         "context": [
           {
-            "id": "postcode.7586275482125420",
+            "id": "postcode.123",
             "text": "63441"
           },
           {
-            "id": "place.16531927802291200",
+            "id": "place.123",
             "wikidata": "Q960791",
             "text": "Frankford"
           },
           {
-            "id": "region.28004",
+            "id": "region.123",
             "short_code": "US-MO",
             "wikidata": "Q1581",
             "text": "Missouri"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "short_code": "us",
             "wikidata": "Q30",
             "text": "United States"
@@ -145,7 +145,7 @@
         ]
       },
       {
-        "id": "address.3374631738293172",
+        "id": "address.123",
         "type": "Feature",
         "place_type": [
           "address"
@@ -155,34 +155,34 @@
         "text": "20001 Painted Cup Dr",
         "place_name": "20001 Painted Cup Dr, Unionville, Missouri 63565, United States",
         "center": [
-          -93.01847,
-          40.511112
+          -93,
+          40
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -93.01847,
-            40.511112
+            -93,
+            40
           ]
         },
         "context": [
           {
-            "id": "postcode.13217932637767190",
+            "id": "postcode.123",
             "text": "63565"
           },
           {
-            "id": "place.10055886748333240",
+            "id": "place.123",
             "wikidata": "Q598853",
             "text": "Unionville"
           },
           {
-            "id": "region.28004",
+            "id": "region.123",
             "short_code": "US-MO",
             "wikidata": "Q1581",
             "text": "Missouri"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "short_code": "us",
             "wikidata": "Q30",
             "text": "United States"
@@ -190,7 +190,7 @@
         ]
       },
       {
-        "id": "address.1212803431057912",
+        "id": "address.1",
         "type": "Feature",
         "place_type": [
           "address"
@@ -200,34 +200,34 @@
         "text": "20001",
         "place_name": "20001, Mc Alpin, Florida 32062, United States",
         "center": [
-          -82.94874,
-          30.085461
+          -82,
+          30
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -82.94874,
-            30.085461
+            -82,
+            30
           ]
         },
         "context": [
           {
-            "id": "postcode.6857120106983010",
+            "id": "postcode.123",
             "text": "32062"
           },
           {
-            "id": "place.4536624049214180",
+            "id": "place.123",
             "wikidata": null,
             "text": "Mc Alpin"
           },
           {
-            "id": "region.3865",
+            "id": "region.123",
             "short_code": "US-FL",
             "wikidata": "Q812",
             "text": "Florida"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "short_code": "us",
             "wikidata": "Q30",
             "text": "United States"
@@ -244,7 +244,7 @@
     ],
     "features": [
       {
-        "id": "postcode.17502531659389280",
+        "id": "postcode.123",
         "type": "Feature",
         "place_type": [
           "postcode"
@@ -254,36 +254,36 @@
         "text": "20001",
         "place_name": "Washington, District of Columbia 20001, United States",
         "bbox": [
-          -77.0282940080508,
-          38.890665010602,
-          -77.0071750094517,
-          38.9292809921057
+          -77,
+          38,
+          -77,
+          38
         ],
         "center": [
-          -77.02,
-          38.9
+          -77,
+          38
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -77.02,
-            38.9
+            -77,
+            38
           ]
         },
         "context": [
           {
-            "id": "place.7673410831246050",
+            "id": "place.123",
             "wikidata": "Q61",
             "text": "Washington"
           },
           {
-            "id": "region.3403",
+            "id": "region.123",
             "short_code": "US-DC",
             "wikidata": "Q61",
             "text": "District of Columbia"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "short_code": "us",
             "wikidata": "Q30",
             "text": "United States"
@@ -291,7 +291,7 @@
         ]
       },
       {
-        "id": "postcode.14626046980389280",
+        "id": "postcode.123",
         "type": "Feature",
         "place_type": [
           "postcode"
@@ -301,10 +301,10 @@
         "text": "20001",
         "place_name": "20001, Donostia, Gipuzkoa, Spain",
         "bbox": [
-          -1.977172,
-          43.320914,
-          -1.969088,
-          43.326066
+          -1,
+          43,
+          -1,
+          43
         ],
         "center": [
           -1.972363,
@@ -313,24 +313,24 @@
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -1.972363,
-            43.323461
+            -1,
+            43
           ]
         },
         "context": [
           {
-            "id": "place.17550260039396600",
+            "id": "place.123",
             "wikidata": "Q10313",
             "text": "Donostia"
           },
           {
-            "id": "region.225124",
+            "id": "region.123",
             "short_code": "ES-SS",
             "wikidata": "Q95010",
             "text": "Gipuzkoa"
           },
           {
-            "id": "country.3110",
+            "id": "country.123",
             "short_code": "es",
             "wikidata": "Q29",
             "text": "Spain"
@@ -338,7 +338,7 @@
         ]
       },
       {
-        "id": "address.6162352618677344",
+        "id": "address.123",
         "type": "Feature",
         "place_type": [
           "address"
@@ -348,34 +348,34 @@
         "text": "20001 Westside Dr",
         "place_name": "20001 Westside Dr, Frankford, Missouri 63441, United States",
         "center": [
-          -91.36103,
-          39.533667
+          -91,
+          39
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -91.36103,
-            39.533667
+            -91,
+            39
           ]
         },
         "context": [
           {
-            "id": "postcode.7586275482125420",
+            "id": "postcode.123",
             "text": "63441"
           },
           {
-            "id": "place.16531927802291200",
+            "id": "place.123",
             "wikidata": "Q960791",
             "text": "Frankford"
           },
           {
-            "id": "region.28004",
+            "id": "region.123",
             "short_code": "US-MO",
             "wikidata": "Q1581",
             "text": "Missouri"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "short_code": "us",
             "wikidata": "Q30",
             "text": "United States"
@@ -383,7 +383,7 @@
         ]
       },
       {
-        "id": "address.3374631738293172",
+        "id": "address.123",
         "type": "Feature",
         "place_type": [
           "address"
@@ -393,34 +393,34 @@
         "text": "20001 Painted Cup Dr",
         "place_name": "20001 Painted Cup Dr, Unionville, Missouri 63565, United States",
         "center": [
-          -93.01847,
-          40.511112
+          -93,
+          40
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -93.01847,
-            40.511112
+            -93,
+            40
           ]
         },
         "context": [
           {
-            "id": "postcode.13217932637767190",
+            "id": "postcode.123",
             "text": "63565"
           },
           {
-            "id": "place.10055886748333240",
+            "id": "place.123",
             "wikidata": "Q598853",
             "text": "Unionville"
           },
           {
-            "id": "region.28004",
+            "id": "region.123",
             "short_code": "US-MO",
             "wikidata": "Q1581",
             "text": "Missouri"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "short_code": "us",
             "wikidata": "Q30",
             "text": "United States"
@@ -428,7 +428,7 @@
         ]
       },
       {
-        "id": "address.1212803431057912",
+        "id": "address.123",
         "type": "Feature",
         "place_type": [
           "address"
@@ -438,34 +438,34 @@
         "text": "20001",
         "place_name": "20001, Mc Alpin, Florida 32062, United States",
         "center": [
-          -82.94874,
-          30.085461
+          -82,
+          30
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -82.94874,
-            30.085461
+            -82,
+            30
           ]
         },
         "context": [
           {
-            "id": "postcode.6857120106983010",
+            "id": "postcode.123",
             "text": "32062"
           },
           {
-            "id": "place.4536624049214180",
+            "id": "place.123",
             "wikidata": null,
             "text": "Mc Alpin"
           },
           {
-            "id": "region.3865",
+            "id": "region.123",
             "short_code": "US-FL",
             "wikidata": "Q812",
             "text": "Florida"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "short_code": "us",
             "wikidata": "Q30",
             "text": "United States"
@@ -482,7 +482,7 @@
     ],
     "features": [
       {
-        "id": "postcode.17502531659389280",
+        "id": "postcode.123",
         "type": "Feature",
         "place_type": [
           "postcode"
@@ -492,36 +492,36 @@
         "text": "20001",
         "place_name": "Washington, District of Columbia 20001, United States",
         "bbox": [
-          -77.0282940080508,
-          38.890665010602,
-          -77.0071750094517,
-          38.9292809921057
+          -77,
+          38,
+          -77,
+          38
         ],
         "center": [
-          -77.02,
-          38.9
+          -77,
+          39
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -77.02,
-            38.9
+            -77,
+            38
           ]
         },
         "context": [
           {
-            "id": "place.7673410831246050",
+            "id": "place.123",
             "wikidata": "Q61",
             "text": "Washington"
           },
           {
-            "id": "region.3403",
+            "id": "region.123",
             "short_code": "US-DC",
             "wikidata": "Q61",
             "text": "District of Columbia"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "short_code": "us",
             "wikidata": "Q30",
             "text": "United States"
@@ -529,7 +529,7 @@
         ]
       },
       {
-        "id": "postcode.14626046980389280",
+        "id": "postcode.123",
         "type": "Feature",
         "place_type": [
           "postcode"
@@ -539,36 +539,36 @@
         "text": "20001",
         "place_name": "20001, Donostia, Gipuzkoa, Spain",
         "bbox": [
-          -1.977172,
-          43.320914,
-          -1.969088,
-          43.326066
+          -1,
+          43,
+          -1,
+          43
         ],
         "center": [
-          -1.972363,
-          43.323461
+          -1,
+          43
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -1.972363,
-            43.323461
+            -1,
+            43
           ]
         },
         "context": [
           {
-            "id": "place.17550260039396600",
+            "id": "place.123",
             "wikidata": "Q10313",
             "text": "Donostia"
           },
           {
-            "id": "region.225124",
+            "id": "region.123",
             "short_code": "ES-SS",
             "wikidata": "Q95010",
             "text": "Gipuzkoa"
           },
           {
-            "id": "country.3110",
+            "id": "country.123",
             "short_code": "es",
             "wikidata": "Q29",
             "text": "Spain"
@@ -576,7 +576,7 @@
         ]
       },
       {
-        "id": "address.6162352618677344",
+        "id": "address.123",
         "type": "Feature",
         "place_type": [
           "address"
@@ -586,34 +586,34 @@
         "text": "20001 Westside Dr",
         "place_name": "20001 Westside Dr, Frankford, Missouri 63441, United States",
         "center": [
-          -91.36103,
-          39.533667
+          -91,
+          39
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -91.36103,
-            39.533667
+            -91,
+            39
           ]
         },
         "context": [
           {
-            "id": "postcode.7586275482125420",
+            "id": "postcode.123",
             "text": "63441"
           },
           {
-            "id": "place.16531927802291200",
+            "id": "place.123",
             "wikidata": "Q960791",
             "text": "Frankford"
           },
           {
-            "id": "region.28004",
+            "id": "region.123",
             "short_code": "US-MO",
             "wikidata": "Q1581",
             "text": "Missouri"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "short_code": "us",
             "wikidata": "Q30",
             "text": "United States"
@@ -621,7 +621,7 @@
         ]
       },
       {
-        "id": "address.3374631738293172",
+        "id": "address.123",
         "type": "Feature",
         "place_type": [
           "address"
@@ -631,34 +631,34 @@
         "text": "20001 Painted Cup Dr",
         "place_name": "20001 Painted Cup Dr, Unionville, Missouri 63565, United States",
         "center": [
-          -93.01847,
-          40.511112
+          -93,
+          40
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -93.01847,
-            40.511112
+            -93,
+            40
           ]
         },
         "context": [
           {
-            "id": "postcode.13217932637767190",
+            "id": "postcode.123",
             "text": "63565"
           },
           {
-            "id": "place.10055886748333240",
+            "id": "place.123",
             "wikidata": "Q598853",
             "text": "Unionville"
           },
           {
-            "id": "region.28004",
+            "id": "region.123",
             "short_code": "US-MO",
             "wikidata": "Q1581",
             "text": "Missouri"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "short_code": "us",
             "wikidata": "Q30",
             "text": "United States"
@@ -666,7 +666,7 @@
         ]
       },
       {
-        "id": "address.1212803431057912",
+        "id": "address.1",
         "type": "Feature",
         "place_type": [
           "address"
@@ -676,14 +676,14 @@
         "text": "20001",
         "place_name": "20001, Mc Alpin, Florida 32062, United States",
         "center": [
-          -82.94874,
-          30.085461
+          -82,
+          30
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -82.94874,
-            30.085461
+            -82,
+            30
           ]
         },
         "context": [

--- a/MapboxGeocoderTests/fixtures/permanent_forward_single_no_results.json
+++ b/MapboxGeocoderTests/fixtures/permanent_forward_single_no_results.json
@@ -1,0 +1,11 @@
+{
+    "type": "FeatureCollection",
+    "query": [
+              "m",
+              "pb0x"
+              ],
+    "features": [
+    
+    ],
+    "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+}

--- a/MapboxGeocoderTests/fixtures/permanent_forward_single_valid.json
+++ b/MapboxGeocoderTests/fixtures/permanent_forward_single_valid.json
@@ -1,0 +1,265 @@
+{
+    "type": "FeatureCollection",
+    "query": [
+              "85",
+              "2nd",
+              "st",
+              "san",
+              "francisco"
+              ],
+    "features": [
+                 {
+                 "id": "address.7841615459939754",
+                 "type": "Feature",
+                 "place_type": [
+                                "address"
+                                ],
+                 "relevance": 1,
+                 "properties": {
+                 
+                 },
+                 "text": "2nd Street",
+                 "place_name": "85 2nd Street, San Francisco, California 94105, United States",
+                 "center": [
+                            -122.39988,
+                            37.788457
+                            ],
+                 "geometry": {
+                 "type": "Point",
+                 "coordinates": [
+                                 -122.39988,
+                                 37.788457
+                                 ]
+                 },
+                 "address": "85",
+                 "context": [
+                             {
+                             "id": "neighborhood.293324",
+                             "text": "South Beach"
+                             },
+                             {
+                             "id": "postcode.17577055718678700",
+                             "text": "94105"
+                             },
+                             {
+                             "id": "place.15734669613361910",
+                             "wikidata": "Q62",
+                             "text": "San Francisco"
+                             },
+                             {
+                             "id": "region.3591",
+                             "short_code": "US-CA",
+                             "wikidata": "Q99",
+                             "text": "California"
+                             },
+                             {
+                             "id": "country.3145",
+                             "short_code": "us",
+                             "wikidata": "Q30",
+                             "text": "United States"
+                             }
+                             ]
+                 },
+                 {
+                 "id": "address.6385738408209164",
+                 "type": "Feature",
+                 "place_type": [
+                                "address"
+                                ],
+                 "relevance": 1,
+                 "properties": {
+                 
+                 },
+                 "text": "2nd Street",
+                 "place_name": "85 2nd Street, San Francisco Plaza, New Mexico 87830, United States",
+                 "center": [
+                            -108.76483,
+                            33.71057
+                            ],
+                 "geometry": {
+                 "type": "Point",
+                 "coordinates": [
+                                 -108.76483,
+                                 33.71057
+                                 ],
+                 "interpolated": true,
+                 "omitted": true
+                 },
+                 "address": "85",
+                 "context": [
+                             {
+                             "id": "postcode.10092384394414280",
+                             "text": "87830"
+                             },
+                             {
+                             "id": "place.10359225601084080",
+                             "wikidata": null,
+                             "text": "San Francisco Plaza"
+                             },
+                             {
+                             "id": "region.215680",
+                             "short_code": "US-NM",
+                             "wikidata": "Q1522",
+                             "text": "New Mexico"
+                             },
+                             {
+                             "id": "country.3145",
+                             "short_code": "us",
+                             "wikidata": "Q30",
+                             "text": "United States"
+                             }
+                             ]
+                 },
+                 {
+                 "id": "address.8787081457370924",
+                 "type": "Feature",
+                 "place_type": [
+                                "address"
+                                ],
+                 "relevance": 0.9,
+                 "properties": {
+                 
+                 },
+                 "text": "2nd Street",
+                 "place_name": "85 2nd Street, South San Francisco, California 94080, United States",
+                 "center": [
+                            -122.430791,
+                            37.652239
+                            ],
+                 "geometry": {
+                 "type": "Point",
+                 "coordinates": [
+                                 -122.430791,
+                                 37.652239
+                                 ],
+                 "interpolated": true
+                 },
+                 "address": "85",
+                 "context": [
+                             {
+                             "id": "neighborhood.285770",
+                             "text": "El Camino"
+                             },
+                             {
+                             "id": "postcode.6085630704695250",
+                             "text": "94080"
+                             },
+                             {
+                             "id": "place.13348514000534220",
+                             "wikidata": "Q927122",
+                             "text": "South San Francisco"
+                             },
+                             {
+                             "id": "region.3591",
+                             "short_code": "US-CA",
+                             "wikidata": "Q99",
+                             "text": "California"
+                             },
+                             {
+                             "id": "country.3145",
+                             "short_code": "us",
+                             "wikidata": "Q30",
+                             "text": "United States"
+                             }
+                             ]
+                 },
+                 {
+                 "id": "place.15734669613361910",
+                 "type": "Feature",
+                 "place_type": [
+                                "place"
+                                ],
+                 "relevance": 0.5,
+                 "properties": {
+                 "wikidata": "Q62"
+                 },
+                 "text": "San Francisco",
+                 "place_name": "San Francisco, California, United States",
+                 "bbox": [
+                          -122.517910874663,
+                          37.6044780500533,
+                          -122.354995082683,
+                          37.8324430069081
+                          ],
+                 "center": [
+                            -122.463,
+                            37.7648
+                            ],
+                 "geometry": {
+                 "type": "Point",
+                 "coordinates": [
+                                 -122.463,
+                                 37.7648
+                                 ]
+                 },
+                 "context": [
+                             {
+                             "id": "region.3591",
+                             "short_code": "US-CA",
+                             "wikidata": "Q99",
+                             "text": "California"
+                             },
+                             {
+                             "id": "country.3145",
+                             "short_code": "us",
+                             "wikidata": "Q30",
+                             "text": "United States"
+                             }
+                             ]
+                 },
+                 {
+                 "id": "locality.15048882226361910",
+                 "type": "Feature",
+                 "place_type": [
+                                "locality"
+                                ],
+                 "relevance": 0.5,
+                 "properties": {
+                 
+                 },
+                 "text": "San Francisco",
+                 "place_name": "San Francisco, 4024, Biñan, Laguna, Philippines",
+                 "bbox": [
+                          121.006896972656,
+                          14.3116598129272,
+                          121.061897277832,
+                          14.3412103652955
+                          ],
+                 "center": [
+                            121.03,
+                            14.33
+                            ],
+                 "geometry": {
+                 "type": "Point",
+                 "coordinates": [
+                                 121.03,
+                                 14.33
+                                 ]
+                 },
+                 "context": [
+                             {
+                             "id": "postcode.5893440692154820",
+                             "text": "4024"
+                             },
+                             {
+                             "id": "place.8969748587290700",
+                             "wikidata": "Q75961",
+                             "text": "Biñan"
+                             },
+                             {
+                             "id": "region.220373",
+                             "short_code": "PH-LAG",
+                             "wikidata": "Q13840",
+                             "text": "Laguna"
+                             },
+                             {
+                             "id": "country.323",
+                             "short_code": "ph",
+                             "wikidata": "Q928",
+                             "text": "Philippines"
+                             }
+                             ]
+                 }
+                 ],
+    "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+}

--- a/MapboxGeocoderTests/fixtures/permanent_forward_single_valid.json
+++ b/MapboxGeocoderTests/fixtures/permanent_forward_single_valid.json
@@ -9,7 +9,7 @@
               ],
     "features": [
                  {
-                 "id": "address.7841615459939754",
+                 "id": "address.123",
                  "type": "Feature",
                  "place_type": [
                                 "address"
@@ -21,39 +21,39 @@
                  "text": "2nd Street",
                  "place_name": "85 2nd Street, San Francisco, California 94105, United States",
                  "center": [
-                            -122.39988,
-                            37.788457
+                            -122,
+                            37
                             ],
                  "geometry": {
                  "type": "Point",
                  "coordinates": [
-                                 -122.39988,
-                                 37.788457
+                                 -122123,
+                                 37
                                  ]
                  },
                  "address": "85",
                  "context": [
                              {
-                             "id": "neighborhood.293324",
+                             "id": "neighborhood.123",
                              "text": "South Beach"
                              },
                              {
-                             "id": "postcode.17577055718678700",
+                             "id": "postcode.123",
                              "text": "94105"
                              },
                              {
-                             "id": "place.15734669613361910",
+                             "id": "place.123",
                              "wikidata": "Q62",
                              "text": "San Francisco"
                              },
                              {
-                             "id": "region.3591",
+                             "id": "region.123",
                              "short_code": "US-CA",
                              "wikidata": "Q99",
                              "text": "California"
                              },
                              {
-                             "id": "country.3145",
+                             "id": "country.123",
                              "short_code": "us",
                              "wikidata": "Q30",
                              "text": "United States"
@@ -61,7 +61,7 @@
                              ]
                  },
                  {
-                 "id": "address.6385738408209164",
+                 "id": "address.123",
                  "type": "Feature",
                  "place_type": [
                                 "address"
@@ -73,14 +73,14 @@
                  "text": "2nd Street",
                  "place_name": "85 2nd Street, San Francisco Plaza, New Mexico 87830, United States",
                  "center": [
-                            -108.76483,
-                            33.71057
+                            -108,
+                            33
                             ],
                  "geometry": {
                  "type": "Point",
                  "coordinates": [
-                                 -108.76483,
-                                 33.71057
+                                 -108,
+                                 33
                                  ],
                  "interpolated": true,
                  "omitted": true
@@ -88,22 +88,22 @@
                  "address": "85",
                  "context": [
                              {
-                             "id": "postcode.10092384394414280",
+                             "id": "postcode.123",
                              "text": "87830"
                              },
                              {
-                             "id": "place.10359225601084080",
+                             "id": "place.123",
                              "wikidata": null,
                              "text": "San Francisco Plaza"
                              },
                              {
-                             "id": "region.215680",
+                             "id": "region.123",
                              "short_code": "US-NM",
                              "wikidata": "Q1522",
                              "text": "New Mexico"
                              },
                              {
-                             "id": "country.3145",
+                             "id": "country.123",
                              "short_code": "us",
                              "wikidata": "Q30",
                              "text": "United States"
@@ -111,7 +111,7 @@
                              ]
                  },
                  {
-                 "id": "address.8787081457370924",
+                 "id": "address.123",
                  "type": "Feature",
                  "place_type": [
                                 "address"
@@ -123,40 +123,40 @@
                  "text": "2nd Street",
                  "place_name": "85 2nd Street, South San Francisco, California 94080, United States",
                  "center": [
-                            -122.430791,
-                            37.652239
+                            -122,
+                            37
                             ],
                  "geometry": {
                  "type": "Point",
                  "coordinates": [
-                                 -122.430791,
-                                 37.652239
+                                 -122,
+                                 37
                                  ],
                  "interpolated": true
                  },
                  "address": "85",
                  "context": [
                              {
-                             "id": "neighborhood.285770",
+                             "id": "neighborhood.123",
                              "text": "El Camino"
                              },
                              {
-                             "id": "postcode.6085630704695250",
+                             "id": "postcode.123",
                              "text": "94080"
                              },
                              {
-                             "id": "place.13348514000534220",
+                             "id": "place.123",
                              "wikidata": "Q927122",
                              "text": "South San Francisco"
                              },
                              {
-                             "id": "region.3591",
+                             "id": "region.123",
                              "short_code": "US-CA",
                              "wikidata": "Q99",
                              "text": "California"
                              },
                              {
-                             "id": "country.3145",
+                             "id": "country.123",
                              "short_code": "us",
                              "wikidata": "Q30",
                              "text": "United States"
@@ -164,7 +164,7 @@
                              ]
                  },
                  {
-                 "id": "place.15734669613361910",
+                 "id": "place.123",
                  "type": "Feature",
                  "place_type": [
                                 "place"
@@ -176,31 +176,31 @@
                  "text": "San Francisco",
                  "place_name": "San Francisco, California, United States",
                  "bbox": [
-                          -122.517910874663,
-                          37.6044780500533,
-                          -122.354995082683,
-                          37.8324430069081
+                          -122,
+                          37,
+                          -122,
+                          37
                           ],
                  "center": [
-                            -122.463,
-                            37.7648
+                            -122,
+                            37
                             ],
                  "geometry": {
                  "type": "Point",
                  "coordinates": [
-                                 -122.463,
-                                 37.7648
+                                 -122,
+                                 37
                                  ]
                  },
                  "context": [
                              {
-                             "id": "region.3591",
+                             "id": "region.123",
                              "short_code": "US-CA",
                              "wikidata": "Q99",
                              "text": "California"
                              },
                              {
-                             "id": "country.3145",
+                             "id": "country.123",
                              "short_code": "us",
                              "wikidata": "Q30",
                              "text": "United States"
@@ -208,7 +208,7 @@
                              ]
                  },
                  {
-                 "id": "locality.15048882226361910",
+                 "id": "locality.123",
                  "type": "Feature",
                  "place_type": [
                                 "locality"
@@ -220,40 +220,40 @@
                  "text": "San Francisco",
                  "place_name": "San Francisco, 4024, Biñan, Laguna, Philippines",
                  "bbox": [
-                          121.006896972656,
-                          14.3116598129272,
-                          121.061897277832,
-                          14.3412103652955
+                          121,
+                          14,
+                          121,
+                          14
                           ],
                  "center": [
-                            121.03,
-                            14.33
+                            121,
+                            14
                             ],
                  "geometry": {
                  "type": "Point",
                  "coordinates": [
-                                 121.03,
-                                 14.33
+                                 121,
+                                 14
                                  ]
                  },
                  "context": [
                              {
-                             "id": "postcode.5893440692154820",
+                             "id": "postcode.123",
                              "text": "4024"
                              },
                              {
-                             "id": "place.8969748587290700",
+                             "id": "place.123",
                              "wikidata": "Q75961",
                              "text": "Biñan"
                              },
                              {
-                             "id": "region.220373",
+                             "id": "region.123",
                              "short_code": "PH-LAG",
                              "wikidata": "Q13840",
                              "text": "Laguna"
                              },
                              {
-                             "id": "country.323",
+                             "id": "country.123",
                              "short_code": "ph",
                              "wikidata": "Q928",
                              "text": "Philippines"

--- a/MapboxGeocoderTests/fixtures/permanent_invalid.json
+++ b/MapboxGeocoderTests/fixtures/permanent_invalid.json
@@ -1,0 +1,3 @@
+{
+  "message": "Not Found"
+}

--- a/MapboxGeocoderTests/fixtures/permanent_invalid_token.json
+++ b/MapboxGeocoderTests/fixtures/permanent_invalid_token.json
@@ -1,0 +1,3 @@
+{
+  "message": "Not Authorized - Invalid Token"
+}

--- a/MapboxGeocoderTests/fixtures/permanent_invalid_token_scope.json
+++ b/MapboxGeocoderTests/fixtures/permanent_invalid_token_scope.json
@@ -1,0 +1,3 @@
+{
+  "message": "Permanent geocodes are not enabled for this account. Contact support@mapbox.com to enable this feature."
+}

--- a/MapboxGeocoderTests/fixtures/permanent_reverse_multiple_no_results.json
+++ b/MapboxGeocoderTests/fixtures/permanent_reverse_multiple_no_results.json
@@ -1,0 +1,35 @@
+[
+ {
+ "type": "FeatureCollection",
+ "query": [
+           100,
+           100
+           ],
+ "features": [
+ 
+ ],
+ "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+ },
+ {
+ "type": "FeatureCollection",
+ "query": [
+           100,
+           100
+           ],
+ "features": [
+ 
+ ],
+ "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+ },
+ {
+ "type": "FeatureCollection",
+ "query": [
+           100,
+           100
+           ],
+ "features": [
+ 
+ ],
+ "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+ }
+ ]

--- a/MapboxGeocoderTests/fixtures/permanent_reverse_multiple_valid.json
+++ b/MapboxGeocoderTests/fixtures/permanent_reverse_multiple_valid.json
@@ -1,0 +1,833 @@
+[
+  {
+    "type": "FeatureCollection",
+    "query": [
+      -77.01073,
+      38.88887
+    ],
+    "features": [
+      {
+        "id": "address.947761358000488",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "relevance": 1,
+        "properties": {
+          
+        },
+        "text": "South Capitol Circle Southwest",
+        "place_name": "South Capitol Circle Southwest, Washington, District of Columbia 20002, United States",
+        "center": [
+          -77.01128468714641,
+          38.88799842529652
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.01128468714641,
+            38.88799842529652
+          ]
+        },
+        "context": [
+          {
+            "id": "neighborhood.294527",
+            "text": "Capitol Hill"
+          },
+          {
+            "id": "postcode.8356485856998370",
+            "text": "20002"
+          },
+          {
+            "id": "place.7673410831246050",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "neighborhood.294527",
+        "type": "Feature",
+        "place_type": [
+          "neighborhood"
+        ],
+        "relevance": 1,
+        "properties": {
+          
+        },
+        "text": "Capitol Hill",
+        "place_name": "Capitol Hill, Washington, District of Columbia 20002, United States",
+        "bbox": [
+          -77.014329,
+          38.876986,
+          -76.983582,
+          38.897326
+        ],
+        "center": [
+          -77.0003,
+          38.889
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.0003,
+            38.889
+          ]
+        },
+        "context": [
+          {
+            "id": "postcode.8356485856998370",
+            "text": "20002"
+          },
+          {
+            "id": "place.7673410831246050",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "postcode.8356485856998370",
+        "type": "Feature",
+        "place_type": [
+          "postcode"
+        ],
+        "relevance": 1,
+        "properties": {
+          
+        },
+        "text": "20002",
+        "place_name": "Washington, District of Columbia 20002, United States",
+        "bbox": [
+          -77.0124999956368,
+          38.8875859940734,
+          -76.9438559927196,
+          38.9270120045122
+        ],
+        "center": [
+          -77.01,
+          38.89
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.01,
+            38.89
+          ]
+        },
+        "context": [
+          {
+            "id": "place.7673410831246050",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "place.7673410831246050",
+        "type": "Feature",
+        "place_type": [
+          "place"
+        ],
+        "relevance": 1,
+        "properties": {
+          "wikidata": "Q61"
+        },
+        "text": "Washington",
+        "place_name": "Washington, District of Columbia, United States",
+        "bbox": [
+          -77.1197609567342,
+          38.79155738,
+          -76.909391,
+          38.99555093
+        ],
+        "center": [
+          -77.0366,
+          38.895
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.0366,
+            38.895
+          ]
+        },
+        "context": [
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "region.3403",
+        "type": "Feature",
+        "place_type": [
+          "region"
+        ],
+        "relevance": 1,
+        "properties": {
+          "short_code": "US-DC",
+          "wikidata": "Q61"
+        },
+        "text": "District of Columbia",
+        "place_name": "District of Columbia, United States",
+        "bbox": [
+          -77.208138,
+          38.717703,
+          -76.909393,
+          38.995548
+        ],
+        "center": [
+          -76.990513,
+          38.896391
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -76.990513,
+            38.896391
+          ]
+        },
+        "context": [
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "country.3145",
+        "type": "Feature",
+        "place_type": [
+          "country"
+        ],
+        "relevance": 1,
+        "properties": {
+          "wikidata": "Q30",
+          "short_code": "us"
+        },
+        "text": "United States",
+        "place_name": "United States",
+        "bbox": [
+          -179.9,
+          -14.6528,
+          -64.464198,
+          71.540724
+        ],
+        "center": [
+          -97.922211,
+          39.381266
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -97.922211,
+            39.381266
+          ]
+        }
+      }
+    ],
+    "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+  },
+  {
+    "type": "FeatureCollection",
+    "query": [
+      -77.01073,
+      38.88887
+    ],
+    "features": [
+      {
+        "id": "address.947761358000488",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "relevance": 1,
+        "properties": {
+          
+        },
+        "text": "South Capitol Circle Southwest",
+        "place_name": "South Capitol Circle Southwest, Washington, District of Columbia 20002, United States",
+        "center": [
+          -77.01128468714641,
+          38.88799842529652
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.01128468714641,
+            38.88799842529652
+          ]
+        },
+        "context": [
+          {
+            "id": "neighborhood.294527",
+            "text": "Capitol Hill"
+          },
+          {
+            "id": "postcode.8356485856998370",
+            "text": "20002"
+          },
+          {
+            "id": "place.7673410831246050",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "neighborhood.294527",
+        "type": "Feature",
+        "place_type": [
+          "neighborhood"
+        ],
+        "relevance": 1,
+        "properties": {
+          
+        },
+        "text": "Capitol Hill",
+        "place_name": "Capitol Hill, Washington, District of Columbia 20002, United States",
+        "bbox": [
+          -77.014329,
+          38.876986,
+          -76.983582,
+          38.897326
+        ],
+        "center": [
+          -77.0003,
+          38.889
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.0003,
+            38.889
+          ]
+        },
+        "context": [
+          {
+            "id": "postcode.8356485856998370",
+            "text": "20002"
+          },
+          {
+            "id": "place.7673410831246050",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "postcode.8356485856998370",
+        "type": "Feature",
+        "place_type": [
+          "postcode"
+        ],
+        "relevance": 1,
+        "properties": {
+          
+        },
+        "text": "20002",
+        "place_name": "Washington, District of Columbia 20002, United States",
+        "bbox": [
+          -77.0124999956368,
+          38.8875859940734,
+          -76.9438559927196,
+          38.9270120045122
+        ],
+        "center": [
+          -77.01,
+          38.89
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.01,
+            38.89
+          ]
+        },
+        "context": [
+          {
+            "id": "place.7673410831246050",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "place.7673410831246050",
+        "type": "Feature",
+        "place_type": [
+          "place"
+        ],
+        "relevance": 1,
+        "properties": {
+          "wikidata": "Q61"
+        },
+        "text": "Washington",
+        "place_name": "Washington, District of Columbia, United States",
+        "bbox": [
+          -77.1197609567342,
+          38.79155738,
+          -76.909391,
+          38.99555093
+        ],
+        "center": [
+          -77.0366,
+          38.895
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.0366,
+            38.895
+          ]
+        },
+        "context": [
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "region.3403",
+        "type": "Feature",
+        "place_type": [
+          "region"
+        ],
+        "relevance": 1,
+        "properties": {
+          "short_code": "US-DC",
+          "wikidata": "Q61"
+        },
+        "text": "District of Columbia",
+        "place_name": "District of Columbia, United States",
+        "bbox": [
+          -77.208138,
+          38.717703,
+          -76.909393,
+          38.995548
+        ],
+        "center": [
+          -76.990513,
+          38.896391
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -76.990513,
+            38.896391
+          ]
+        },
+        "context": [
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "country.3145",
+        "type": "Feature",
+        "place_type": [
+          "country"
+        ],
+        "relevance": 1,
+        "properties": {
+          "wikidata": "Q30",
+          "short_code": "us"
+        },
+        "text": "United States",
+        "place_name": "United States",
+        "bbox": [
+          -179.9,
+          -14.6528,
+          -64.464198,
+          71.540724
+        ],
+        "center": [
+          -97.922211,
+          39.381266
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -97.922211,
+            39.381266
+          ]
+        }
+      }
+    ],
+    "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+  },
+  {
+    "type": "FeatureCollection",
+    "query": [
+      -77.01073,
+      38.88887
+    ],
+    "features": [
+      {
+        "id": "address.947761358000488",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "relevance": 1,
+        "properties": {
+          
+        },
+        "text": "South Capitol Circle Southwest",
+        "place_name": "South Capitol Circle Southwest, Washington, District of Columbia 20002, United States",
+        "center": [
+          -77.01128468714641,
+          38.88799842529652
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.01128468714641,
+            38.88799842529652
+          ]
+        },
+        "context": [
+          {
+            "id": "neighborhood.294527",
+            "text": "Capitol Hill"
+          },
+          {
+            "id": "postcode.8356485856998370",
+            "text": "20002"
+          },
+          {
+            "id": "place.7673410831246050",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "neighborhood.294527",
+        "type": "Feature",
+        "place_type": [
+          "neighborhood"
+        ],
+        "relevance": 1,
+        "properties": {
+          
+        },
+        "text": "Capitol Hill",
+        "place_name": "Capitol Hill, Washington, District of Columbia 20002, United States",
+        "bbox": [
+          -77.014329,
+          38.876986,
+          -76.983582,
+          38.897326
+        ],
+        "center": [
+          -77.0003,
+          38.889
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.0003,
+            38.889
+          ]
+        },
+        "context": [
+          {
+            "id": "postcode.8356485856998370",
+            "text": "20002"
+          },
+          {
+            "id": "place.7673410831246050",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "postcode.8356485856998370",
+        "type": "Feature",
+        "place_type": [
+          "postcode"
+        ],
+        "relevance": 1,
+        "properties": {
+          
+        },
+        "text": "20002",
+        "place_name": "Washington, District of Columbia 20002, United States",
+        "bbox": [
+          -77.0124999956368,
+          38.8875859940734,
+          -76.9438559927196,
+          38.9270120045122
+        ],
+        "center": [
+          -77.01,
+          38.89
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.01,
+            38.89
+          ]
+        },
+        "context": [
+          {
+            "id": "place.7673410831246050",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "place.7673410831246050",
+        "type": "Feature",
+        "place_type": [
+          "place"
+        ],
+        "relevance": 1,
+        "properties": {
+          "wikidata": "Q61"
+        },
+        "text": "Washington",
+        "place_name": "Washington, District of Columbia, United States",
+        "bbox": [
+          -77.1197609567342,
+          38.79155738,
+          -76.909391,
+          38.99555093
+        ],
+        "center": [
+          -77.0366,
+          38.895
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.0366,
+            38.895
+          ]
+        },
+        "context": [
+          {
+            "id": "region.3403",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "region.3403",
+        "type": "Feature",
+        "place_type": [
+          "region"
+        ],
+        "relevance": 1,
+        "properties": {
+          "short_code": "US-DC",
+          "wikidata": "Q61"
+        },
+        "text": "District of Columbia",
+        "place_name": "District of Columbia, United States",
+        "bbox": [
+          -77.208138,
+          38.717703,
+          -76.909393,
+          38.995548
+        ],
+        "center": [
+          -76.990513,
+          38.896391
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -76.990513,
+            38.896391
+          ]
+        },
+        "context": [
+          {
+            "id": "country.3145",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "country.3145",
+        "type": "Feature",
+        "place_type": [
+          "country"
+        ],
+        "relevance": 1,
+        "properties": {
+          "wikidata": "Q30",
+          "short_code": "us"
+        },
+        "text": "United States",
+        "place_name": "United States",
+        "bbox": [
+          -179.9,
+          -14.6528,
+          -64.464198,
+          71.540724
+        ],
+        "center": [
+          -97.922211,
+          39.381266
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -97.922211,
+            39.381266
+          ]
+        }
+      }
+    ],
+    "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+  }
+]

--- a/MapboxGeocoderTests/fixtures/permanent_reverse_multiple_valid.json
+++ b/MapboxGeocoderTests/fixtures/permanent_reverse_multiple_valid.json
@@ -2,12 +2,12 @@
   {
     "type": "FeatureCollection",
     "query": [
-      -77.01073,
-      38.88887
+      -77,
+      38
     ],
     "features": [
       {
-        "id": "address.947761358000488",
+        "id": "address.123",
         "type": "Feature",
         "place_type": [
           "address"
@@ -19,38 +19,38 @@
         "text": "South Capitol Circle Southwest",
         "place_name": "South Capitol Circle Southwest, Washington, District of Columbia 20002, United States",
         "center": [
-          -77.01128468714641,
-          38.88799842529652
+          -77,
+          38
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -77.01128468714641,
-            38.88799842529652
+            -77,
+            38
           ]
         },
         "context": [
           {
-            "id": "neighborhood.294527",
+            "id": "neighborhood.123",
             "text": "Capitol Hill"
           },
           {
-            "id": "postcode.8356485856998370",
+            "id": "postcode.123",
             "text": "20002"
           },
           {
-            "id": "place.7673410831246050",
+            "id": "place.123",
             "wikidata": "Q61",
             "text": "Washington"
           },
           {
-            "id": "region.3403",
+            "id": "region.123",
             "short_code": "US-DC",
             "wikidata": "Q61",
             "text": "District of Columbia"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "wikidata": "Q30",
             "short_code": "us",
             "text": "United States"
@@ -58,7 +58,7 @@
         ]
       },
       {
-        "id": "neighborhood.294527",
+        "id": "neighborhood.123",
         "type": "Feature",
         "place_type": [
           "neighborhood"
@@ -70,40 +70,40 @@
         "text": "Capitol Hill",
         "place_name": "Capitol Hill, Washington, District of Columbia 20002, United States",
         "bbox": [
-          -77.014329,
-          38.876986,
-          -76.983582,
-          38.897326
+          -77,
+          38,
+          -76,
+          38
         ],
         "center": [
-          -77.0003,
-          38.889
+          -77,
+          38
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -77.0003,
-            38.889
+            -77,
+            38
           ]
         },
         "context": [
           {
-            "id": "postcode.8356485856998370",
+            "id": "postcode.123",
             "text": "20002"
           },
           {
-            "id": "place.7673410831246050",
+            "id": "place.123",
             "wikidata": "Q61",
             "text": "Washington"
           },
           {
-            "id": "region.3403",
+            "id": "region.123",
             "short_code": "US-DC",
             "wikidata": "Q61",
             "text": "District of Columbia"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "wikidata": "Q30",
             "short_code": "us",
             "text": "United States"
@@ -111,7 +111,7 @@
         ]
       },
       {
-        "id": "postcode.8356485856998370",
+        "id": "postcode.123",
         "type": "Feature",
         "place_type": [
           "postcode"
@@ -123,36 +123,36 @@
         "text": "20002",
         "place_name": "Washington, District of Columbia 20002, United States",
         "bbox": [
-          -77.0124999956368,
-          38.8875859940734,
-          -76.9438559927196,
-          38.9270120045122
+          -77,
+          38,
+          -76,
+          38
         ],
         "center": [
-          -77.01,
-          38.89
+          -77,
+          38
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -77.01,
-            38.89
+            -77,
+            38
           ]
         },
         "context": [
           {
-            "id": "place.7673410831246050",
+            "id": "place.123",
             "wikidata": "Q61",
             "text": "Washington"
           },
           {
-            "id": "region.3403",
+            "id": "region.123",
             "short_code": "US-DC",
             "wikidata": "Q61",
             "text": "District of Columbia"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "wikidata": "Q30",
             "short_code": "us",
             "text": "United States"
@@ -160,7 +160,7 @@
         ]
       },
       {
-        "id": "place.7673410831246050",
+        "id": "place.123",
         "type": "Feature",
         "place_type": [
           "place"
@@ -172,31 +172,31 @@
         "text": "Washington",
         "place_name": "Washington, District of Columbia, United States",
         "bbox": [
-          -77.1197609567342,
-          38.79155738,
-          -76.909391,
-          38.99555093
+          -77,
+          38,
+          -76,
+          38
         ],
         "center": [
-          -77.0366,
-          38.895
+          -77,
+          38
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -77.0366,
-            38.895
+            -77,
+            38
           ]
         },
         "context": [
           {
-            "id": "region.3403",
+            "id": "region.123",
             "short_code": "US-DC",
             "wikidata": "Q61",
             "text": "District of Columbia"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "wikidata": "Q30",
             "short_code": "us",
             "text": "United States"
@@ -204,7 +204,7 @@
         ]
       },
       {
-        "id": "region.3403",
+        "id": "region.123",
         "type": "Feature",
         "place_type": [
           "region"
@@ -217,25 +217,25 @@
         "text": "District of Columbia",
         "place_name": "District of Columbia, United States",
         "bbox": [
-          -77.208138,
-          38.717703,
-          -76.909393,
-          38.995548
+          -77,
+          38,
+          -76,
+          38
         ],
         "center": [
-          -76.990513,
-          38.896391
+          -76,
+          38
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -76.990513,
-            38.896391
+            -76,
+            38
           ]
         },
         "context": [
           {
-            "id": "country.3145",
+            "id": "country.123",
             "wikidata": "Q30",
             "short_code": "us",
             "text": "United States"
@@ -243,7 +243,7 @@
         ]
       },
       {
-        "id": "country.3145",
+        "id": "country.123",
         "type": "Feature",
         "place_type": [
           "country"
@@ -256,19 +256,296 @@
         "text": "United States",
         "place_name": "United States",
         "bbox": [
-          -179.9,
-          -14.6528,
-          -64.464198,
-          71.540724
+          -179,
+          -14,
+          -64,
+          71
         ],
         "center": [
-          -97.922211,
+          -97,
+          39
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -97,
+            39
+          ]
+        }
+      }
+    ],
+    "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+  },
+  {
+    "type": "FeatureCollection",
+    "query": [
+      -77,
+      38
+    ],
+    "features": [
+      {
+        "id": "address.123",
+        "type": "Feature",
+        "place_type": [
+          "address"
+        ],
+        "relevance": 1,
+        "properties": {
+          
+        },
+        "text": "South Capitol Circle Southwest",
+        "place_name": "South Capitol Circle Southwest, Washington, District of Columbia 20002, United States",
+        "center": [
+          -77,
+          38
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77,
+            38
+          ]
+        },
+        "context": [
+          {
+            "id": "neighborhood.123",
+            "text": "Capitol Hill"
+          },
+          {
+            "id": "postcode.123",
+            "text": "20002"
+          },
+          {
+            "id": "place.123",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.123",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.123",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "neighborhood.123",
+        "type": "Feature",
+        "place_type": [
+          "neighborhood"
+        ],
+        "relevance": 1,
+        "properties": {
+          
+        },
+        "text": "Capitol Hill",
+        "place_name": "Capitol Hill, Washington, District of Columbia 20002, United States",
+        "bbox": [
+          -77,
+          38,
+          -76,
+          38
+        ],
+        "center": [
+          -77,
+          38
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77,
+            38
+          ]
+        },
+        "context": [
+          {
+            "id": "postcode.123",
+            "text": "20002"
+          },
+          {
+            "id": "place.123",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.123",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.123",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "postcode.123",
+        "type": "Feature",
+        "place_type": [
+          "postcode"
+        ],
+        "relevance": 1,
+        "properties": {
+          
+        },
+        "text": "20002",
+        "place_name": "Washington, District of Columbia 20002, United States",
+        "bbox": [
+          -77,
+          38,
+          -76,
+          38
+        ],
+        "center": [
+          -77,
+          38
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77,
+            38
+          ]
+        },
+        "context": [
+          {
+            "id": "place.123",
+            "wikidata": "Q61",
+            "text": "Washington"
+          },
+          {
+            "id": "region.123",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.123",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "place.123",
+        "type": "Feature",
+        "place_type": [
+          "place"
+        ],
+        "relevance": 1,
+        "properties": {
+          "wikidata": "Q61"
+        },
+        "text": "Washington",
+        "place_name": "Washington, District of Columbia, United States",
+        "bbox": [
+          -77,
+          38,
+          -76,
+          38
+        ],
+        "center": [
+          -77,
+          38
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77,
+            38
+          ]
+        },
+        "context": [
+          {
+            "id": "region.123",
+            "short_code": "US-DC",
+            "wikidata": "Q61",
+            "text": "District of Columbia"
+          },
+          {
+            "id": "country.123",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "region.123",
+        "type": "Feature",
+        "place_type": [
+          "region"
+        ],
+        "relevance": 1,
+        "properties": {
+          "short_code": "US-DC",
+          "wikidata": "Q61"
+        },
+        "text": "District of Columbia",
+        "place_name": "District of Columbia, United States",
+        "bbox": [
+          -77,
+          38,
+          -76,
+          38
+        ],
+        "center": [
+          -76,
+          38
+        ],
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -76,
+            38
+          ]
+        },
+        "context": [
+          {
+            "id": "country.123",
+            "wikidata": "Q30",
+            "short_code": "us",
+            "text": "United States"
+          }
+        ]
+      },
+      {
+        "id": "country.123",
+        "type": "Feature",
+        "place_type": [
+          "country"
+        ],
+        "relevance": 1,
+        "properties": {
+          "wikidata": "Q30",
+          "short_code": "us"
+        },
+        "text": "United States",
+        "place_name": "United States",
+        "bbox": [
+          -179,
+          -14,
+          -64,
+          71
+        ],
+        "center": [
+          -97,
           39.381266
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -97.922211,
+            -97,
             39.381266
           ]
         }
@@ -279,12 +556,12 @@
   {
     "type": "FeatureCollection",
     "query": [
-      -77.01073,
-      38.88887
+      -77,
+      38
     ],
     "features": [
       {
-        "id": "address.947761358000488",
+        "id": "address.123",
         "type": "Feature",
         "place_type": [
           "address"
@@ -296,38 +573,38 @@
         "text": "South Capitol Circle Southwest",
         "place_name": "South Capitol Circle Southwest, Washington, District of Columbia 20002, United States",
         "center": [
-          -77.01128468714641,
-          38.88799842529652
+          -77,
+          38
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -77.01128468714641,
-            38.88799842529652
+            -77,
+            38
           ]
         },
         "context": [
           {
-            "id": "neighborhood.294527",
+            "id": "neighborhood.123",
             "text": "Capitol Hill"
           },
           {
-            "id": "postcode.8356485856998370",
+            "id": "postcode.123",
             "text": "20002"
           },
           {
-            "id": "place.7673410831246050",
+            "id": "place.123",
             "wikidata": "Q61",
             "text": "Washington"
           },
           {
-            "id": "region.3403",
+            "id": "region.123",
             "short_code": "US-DC",
             "wikidata": "Q61",
             "text": "District of Columbia"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "wikidata": "Q30",
             "short_code": "us",
             "text": "United States"
@@ -335,7 +612,7 @@
         ]
       },
       {
-        "id": "neighborhood.294527",
+        "id": "neighborhood.123",
         "type": "Feature",
         "place_type": [
           "neighborhood"
@@ -347,40 +624,40 @@
         "text": "Capitol Hill",
         "place_name": "Capitol Hill, Washington, District of Columbia 20002, United States",
         "bbox": [
-          -77.014329,
-          38.876986,
-          -76.983582,
-          38.897326
+          -77,
+          38,
+          -76,
+          38
         ],
         "center": [
-          -77.0003,
-          38.889
+          -77,
+          38
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -77.0003,
-            38.889
+            -77,
+            38
           ]
         },
         "context": [
           {
-            "id": "postcode.8356485856998370",
+            "id": "postcode.123",
             "text": "20002"
           },
           {
-            "id": "place.7673410831246050",
+            "id": "place.123",
             "wikidata": "Q61",
             "text": "Washington"
           },
           {
-            "id": "region.3403",
+            "id": "region.123",
             "short_code": "US-DC",
             "wikidata": "Q61",
             "text": "District of Columbia"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "wikidata": "Q30",
             "short_code": "us",
             "text": "United States"
@@ -388,7 +665,7 @@
         ]
       },
       {
-        "id": "postcode.8356485856998370",
+        "id": "postcode.123",
         "type": "Feature",
         "place_type": [
           "postcode"
@@ -400,36 +677,36 @@
         "text": "20002",
         "place_name": "Washington, District of Columbia 20002, United States",
         "bbox": [
-          -77.0124999956368,
-          38.8875859940734,
-          -76.9438559927196,
-          38.9270120045122
+          -77,
+          38,
+          -76,
+          38
         ],
         "center": [
-          -77.01,
-          38.89
+          -77,
+          38
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -77.01,
-            38.89
+            -77,
+            38
           ]
         },
         "context": [
           {
-            "id": "place.7673410831246050",
+            "id": "place.123",
             "wikidata": "Q61",
             "text": "Washington"
           },
           {
-            "id": "region.3403",
+            "id": "region.123",
             "short_code": "US-DC",
             "wikidata": "Q61",
             "text": "District of Columbia"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "wikidata": "Q30",
             "short_code": "us",
             "text": "United States"
@@ -437,7 +714,7 @@
         ]
       },
       {
-        "id": "place.7673410831246050",
+        "id": "place.123",
         "type": "Feature",
         "place_type": [
           "place"
@@ -449,31 +726,31 @@
         "text": "Washington",
         "place_name": "Washington, District of Columbia, United States",
         "bbox": [
-          -77.1197609567342,
-          38.79155738,
-          -76.909391,
-          38.99555093
+          -77,
+          38,
+          -76,
+          38
         ],
         "center": [
-          -77.0366,
-          38.895
+          -77,
+          38
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -77.0366,
-            38.895
+            -77,
+            38
           ]
         },
         "context": [
           {
-            "id": "region.3403",
+            "id": "region.123",
             "short_code": "US-DC",
             "wikidata": "Q61",
             "text": "District of Columbia"
           },
           {
-            "id": "country.3145",
+            "id": "country.123",
             "wikidata": "Q30",
             "short_code": "us",
             "text": "United States"
@@ -481,7 +758,7 @@
         ]
       },
       {
-        "id": "region.3403",
+        "id": "region.123",
         "type": "Feature",
         "place_type": [
           "region"
@@ -494,25 +771,25 @@
         "text": "District of Columbia",
         "place_name": "District of Columbia, United States",
         "bbox": [
-          -77.208138,
-          38.717703,
-          -76.909393,
-          38.995548
+          -77,
+          38,
+          -76,
+          38
         ],
         "center": [
-          -76.990513,
-          38.896391
+          -76,
+          38
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -76.990513,
-            38.896391
+            -76,
+            38
           ]
         },
         "context": [
           {
-            "id": "country.3145",
+            "id": "country.123",
             "wikidata": "Q30",
             "short_code": "us",
             "text": "United States"
@@ -520,7 +797,7 @@
         ]
       },
       {
-        "id": "country.3145",
+        "id": "country.123",
         "type": "Feature",
         "place_type": [
           "country"
@@ -533,297 +810,20 @@
         "text": "United States",
         "place_name": "United States",
         "bbox": [
-          -179.9,
-          -14.6528,
-          -64.464198,
-          71.540724
+          -179,
+          -14,
+          -64,
+          71
         ],
         "center": [
-          -97.922211,
-          39.381266
+          -97,
+          39
         ],
         "geometry": {
           "type": "Point",
           "coordinates": [
-            -97.922211,
-            39.381266
-          ]
-        }
-      }
-    ],
-    "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
-  },
-  {
-    "type": "FeatureCollection",
-    "query": [
-      -77.01073,
-      38.88887
-    ],
-    "features": [
-      {
-        "id": "address.947761358000488",
-        "type": "Feature",
-        "place_type": [
-          "address"
-        ],
-        "relevance": 1,
-        "properties": {
-          
-        },
-        "text": "South Capitol Circle Southwest",
-        "place_name": "South Capitol Circle Southwest, Washington, District of Columbia 20002, United States",
-        "center": [
-          -77.01128468714641,
-          38.88799842529652
-        ],
-        "geometry": {
-          "type": "Point",
-          "coordinates": [
-            -77.01128468714641,
-            38.88799842529652
-          ]
-        },
-        "context": [
-          {
-            "id": "neighborhood.294527",
-            "text": "Capitol Hill"
-          },
-          {
-            "id": "postcode.8356485856998370",
-            "text": "20002"
-          },
-          {
-            "id": "place.7673410831246050",
-            "wikidata": "Q61",
-            "text": "Washington"
-          },
-          {
-            "id": "region.3403",
-            "short_code": "US-DC",
-            "wikidata": "Q61",
-            "text": "District of Columbia"
-          },
-          {
-            "id": "country.3145",
-            "wikidata": "Q30",
-            "short_code": "us",
-            "text": "United States"
-          }
-        ]
-      },
-      {
-        "id": "neighborhood.294527",
-        "type": "Feature",
-        "place_type": [
-          "neighborhood"
-        ],
-        "relevance": 1,
-        "properties": {
-          
-        },
-        "text": "Capitol Hill",
-        "place_name": "Capitol Hill, Washington, District of Columbia 20002, United States",
-        "bbox": [
-          -77.014329,
-          38.876986,
-          -76.983582,
-          38.897326
-        ],
-        "center": [
-          -77.0003,
-          38.889
-        ],
-        "geometry": {
-          "type": "Point",
-          "coordinates": [
-            -77.0003,
-            38.889
-          ]
-        },
-        "context": [
-          {
-            "id": "postcode.8356485856998370",
-            "text": "20002"
-          },
-          {
-            "id": "place.7673410831246050",
-            "wikidata": "Q61",
-            "text": "Washington"
-          },
-          {
-            "id": "region.3403",
-            "short_code": "US-DC",
-            "wikidata": "Q61",
-            "text": "District of Columbia"
-          },
-          {
-            "id": "country.3145",
-            "wikidata": "Q30",
-            "short_code": "us",
-            "text": "United States"
-          }
-        ]
-      },
-      {
-        "id": "postcode.8356485856998370",
-        "type": "Feature",
-        "place_type": [
-          "postcode"
-        ],
-        "relevance": 1,
-        "properties": {
-          
-        },
-        "text": "20002",
-        "place_name": "Washington, District of Columbia 20002, United States",
-        "bbox": [
-          -77.0124999956368,
-          38.8875859940734,
-          -76.9438559927196,
-          38.9270120045122
-        ],
-        "center": [
-          -77.01,
-          38.89
-        ],
-        "geometry": {
-          "type": "Point",
-          "coordinates": [
-            -77.01,
-            38.89
-          ]
-        },
-        "context": [
-          {
-            "id": "place.7673410831246050",
-            "wikidata": "Q61",
-            "text": "Washington"
-          },
-          {
-            "id": "region.3403",
-            "short_code": "US-DC",
-            "wikidata": "Q61",
-            "text": "District of Columbia"
-          },
-          {
-            "id": "country.3145",
-            "wikidata": "Q30",
-            "short_code": "us",
-            "text": "United States"
-          }
-        ]
-      },
-      {
-        "id": "place.7673410831246050",
-        "type": "Feature",
-        "place_type": [
-          "place"
-        ],
-        "relevance": 1,
-        "properties": {
-          "wikidata": "Q61"
-        },
-        "text": "Washington",
-        "place_name": "Washington, District of Columbia, United States",
-        "bbox": [
-          -77.1197609567342,
-          38.79155738,
-          -76.909391,
-          38.99555093
-        ],
-        "center": [
-          -77.0366,
-          38.895
-        ],
-        "geometry": {
-          "type": "Point",
-          "coordinates": [
-            -77.0366,
-            38.895
-          ]
-        },
-        "context": [
-          {
-            "id": "region.3403",
-            "short_code": "US-DC",
-            "wikidata": "Q61",
-            "text": "District of Columbia"
-          },
-          {
-            "id": "country.3145",
-            "wikidata": "Q30",
-            "short_code": "us",
-            "text": "United States"
-          }
-        ]
-      },
-      {
-        "id": "region.3403",
-        "type": "Feature",
-        "place_type": [
-          "region"
-        ],
-        "relevance": 1,
-        "properties": {
-          "short_code": "US-DC",
-          "wikidata": "Q61"
-        },
-        "text": "District of Columbia",
-        "place_name": "District of Columbia, United States",
-        "bbox": [
-          -77.208138,
-          38.717703,
-          -76.909393,
-          38.995548
-        ],
-        "center": [
-          -76.990513,
-          38.896391
-        ],
-        "geometry": {
-          "type": "Point",
-          "coordinates": [
-            -76.990513,
-            38.896391
-          ]
-        },
-        "context": [
-          {
-            "id": "country.3145",
-            "wikidata": "Q30",
-            "short_code": "us",
-            "text": "United States"
-          }
-        ]
-      },
-      {
-        "id": "country.3145",
-        "type": "Feature",
-        "place_type": [
-          "country"
-        ],
-        "relevance": 1,
-        "properties": {
-          "wikidata": "Q30",
-          "short_code": "us"
-        },
-        "text": "United States",
-        "place_name": "United States",
-        "bbox": [
-          -179.9,
-          -14.6528,
-          -64.464198,
-          71.540724
-        ],
-        "center": [
-          -97.922211,
-          39.381266
-        ],
-        "geometry": {
-          "type": "Point",
-          "coordinates": [
-            -97.922211,
-            39.381266
+            -97,
+            39
           ]
         }
       }

--- a/MapboxGeocoderTests/fixtures/permanent_reverse_single_no_results.json
+++ b/MapboxGeocoderTests/fixtures/permanent_reverse_single_no_results.json
@@ -1,0 +1,11 @@
+{
+    "type": "FeatureCollection",
+    "query": [
+              100,
+              100
+              ],
+    "features": [
+    
+    ],
+    "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+}

--- a/MapboxGeocoderTests/fixtures/permanent_reverse_single_valid.json
+++ b/MapboxGeocoderTests/fixtures/permanent_reverse_single_valid.json
@@ -1,0 +1,277 @@
+{
+  "type": "FeatureCollection",
+  "query": [
+    -77.01073,
+    38.88887
+  ],
+  "features": [
+    {
+      "id": "address.947761358000488",
+      "type": "Feature",
+      "place_type": [
+        "address"
+      ],
+      "relevance": 1,
+      "properties": {
+        
+      },
+      "text": "South Capitol Circle Southwest",
+      "place_name": "South Capitol Circle Southwest, Washington, District of Columbia 20002, United States",
+      "center": [
+        -77.01128468714641,
+        38.88799842529652
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -77.01128468714641,
+          38.88799842529652
+        ]
+      },
+      "context": [
+        {
+          "id": "neighborhood.294527",
+          "text": "Capitol Hill"
+        },
+        {
+          "id": "postcode.8356485856998370",
+          "text": "20002"
+        },
+        {
+          "id": "place.7673410831246050",
+          "wikidata": "Q61",
+          "text": "Washington"
+        },
+        {
+          "id": "region.3403",
+          "short_code": "US-DC",
+          "wikidata": "Q61",
+          "text": "District of Columbia"
+        },
+        {
+          "id": "country.3145",
+          "wikidata": "Q30",
+          "short_code": "us",
+          "text": "United States"
+        }
+      ]
+    },
+    {
+      "id": "neighborhood.294527",
+      "type": "Feature",
+      "place_type": [
+        "neighborhood"
+      ],
+      "relevance": 1,
+      "properties": {
+        
+      },
+      "text": "Capitol Hill",
+      "place_name": "Capitol Hill, Washington, District of Columbia 20002, United States",
+      "bbox": [
+        -77.014329,
+        38.876986,
+        -76.983582,
+        38.897326
+      ],
+      "center": [
+        -77.0003,
+        38.889
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -77.0003,
+          38.889
+        ]
+      },
+      "context": [
+        {
+          "id": "postcode.8356485856998370",
+          "text": "20002"
+        },
+        {
+          "id": "place.7673410831246050",
+          "wikidata": "Q61",
+          "text": "Washington"
+        },
+        {
+          "id": "region.3403",
+          "short_code": "US-DC",
+          "wikidata": "Q61",
+          "text": "District of Columbia"
+        },
+        {
+          "id": "country.3145",
+          "wikidata": "Q30",
+          "short_code": "us",
+          "text": "United States"
+        }
+      ]
+    },
+    {
+      "id": "postcode.8356485856998370",
+      "type": "Feature",
+      "place_type": [
+        "postcode"
+      ],
+      "relevance": 1,
+      "properties": {
+        
+      },
+      "text": "20002",
+      "place_name": "Washington, District of Columbia 20002, United States",
+      "bbox": [
+        -77.0124999956368,
+        38.8875859940734,
+        -76.9438559927196,
+        38.9270120045122
+      ],
+      "center": [
+        -77.01,
+        38.89
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -77.01,
+          38.89
+        ]
+      },
+      "context": [
+        {
+          "id": "place.7673410831246050",
+          "wikidata": "Q61",
+          "text": "Washington"
+        },
+        {
+          "id": "region.3403",
+          "short_code": "US-DC",
+          "wikidata": "Q61",
+          "text": "District of Columbia"
+        },
+        {
+          "id": "country.3145",
+          "wikidata": "Q30",
+          "short_code": "us",
+          "text": "United States"
+        }
+      ]
+    },
+    {
+      "id": "place.7673410831246050",
+      "type": "Feature",
+      "place_type": [
+        "place"
+      ],
+      "relevance": 1,
+      "properties": {
+        "wikidata": "Q61"
+      },
+      "text": "Washington",
+      "place_name": "Washington, District of Columbia, United States",
+      "bbox": [
+        -77.1197609567342,
+        38.79155738,
+        -76.909391,
+        38.99555093
+      ],
+      "center": [
+        -77.0366,
+        38.895
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -77.0366,
+          38.895
+        ]
+      },
+      "context": [
+        {
+          "id": "region.3403",
+          "short_code": "US-DC",
+          "wikidata": "Q61",
+          "text": "District of Columbia"
+        },
+        {
+          "id": "country.3145",
+          "wikidata": "Q30",
+          "short_code": "us",
+          "text": "United States"
+        }
+      ]
+    },
+    {
+      "id": "region.3403",
+      "type": "Feature",
+      "place_type": [
+        "region"
+      ],
+      "relevance": 1,
+      "properties": {
+        "short_code": "US-DC",
+        "wikidata": "Q61"
+      },
+      "text": "District of Columbia",
+      "place_name": "District of Columbia, United States",
+      "bbox": [
+        -77.208138,
+        38.717703,
+        -76.909393,
+        38.995548
+      ],
+      "center": [
+        -76.990513,
+        38.896391
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -76.990513,
+          38.896391
+        ]
+      },
+      "context": [
+        {
+          "id": "country.3145",
+          "wikidata": "Q30",
+          "short_code": "us",
+          "text": "United States"
+        }
+      ]
+    },
+    {
+      "id": "country.3145",
+      "type": "Feature",
+      "place_type": [
+        "country"
+      ],
+      "relevance": 1,
+      "properties": {
+        "wikidata": "Q30",
+        "short_code": "us"
+      },
+      "text": "United States",
+      "place_name": "United States",
+      "bbox": [
+        -179.9,
+        -14.6528,
+        -64.464198,
+        71.540724
+      ],
+      "center": [
+        -97.922211,
+        39.381266
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -97.922211,
+          39.381266
+        ]
+      }
+    }
+  ],
+  "attribution": "© 2017 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service. (https://www.mapbox.com/about/maps/)"
+}

--- a/MapboxGeocoderTests/fixtures/permanent_reverse_single_valid.json
+++ b/MapboxGeocoderTests/fixtures/permanent_reverse_single_valid.json
@@ -1,12 +1,12 @@
 {
   "type": "FeatureCollection",
   "query": [
-    -77.01073,
-    38.88887
+    -77,
+    38
   ],
   "features": [
     {
-      "id": "address.947761358000488",
+      "id": "address.123",
       "type": "Feature",
       "place_type": [
         "address"
@@ -18,38 +18,38 @@
       "text": "South Capitol Circle Southwest",
       "place_name": "South Capitol Circle Southwest, Washington, District of Columbia 20002, United States",
       "center": [
-        -77.01128468714641,
-        38.88799842529652
+        -77,
+        38
       ],
       "geometry": {
         "type": "Point",
         "coordinates": [
-          -77.01128468714641,
-          38.88799842529652
+          -77,
+          38
         ]
       },
       "context": [
         {
-          "id": "neighborhood.294527",
+          "id": "neighborhood.123",
           "text": "Capitol Hill"
         },
         {
-          "id": "postcode.8356485856998370",
+          "id": "postcode.123",
           "text": "20002"
         },
         {
-          "id": "place.7673410831246050",
+          "id": "place.123",
           "wikidata": "Q61",
           "text": "Washington"
         },
         {
-          "id": "region.3403",
+          "id": "region.123",
           "short_code": "US-DC",
           "wikidata": "Q61",
           "text": "District of Columbia"
         },
         {
-          "id": "country.3145",
+          "id": "country.123",
           "wikidata": "Q30",
           "short_code": "us",
           "text": "United States"
@@ -57,7 +57,7 @@
       ]
     },
     {
-      "id": "neighborhood.294527",
+      "id": "neighborhood.123",
       "type": "Feature",
       "place_type": [
         "neighborhood"
@@ -69,14 +69,14 @@
       "text": "Capitol Hill",
       "place_name": "Capitol Hill, Washington, District of Columbia 20002, United States",
       "bbox": [
-        -77.014329,
-        38.876986,
-        -76.983582,
-        38.897326
+        -77,
+        38,
+        -76,
+        38
       ],
       "center": [
-        -77.0003,
-        38.889
+        -77,
+        38
       ],
       "geometry": {
         "type": "Point",
@@ -87,22 +87,22 @@
       },
       "context": [
         {
-          "id": "postcode.8356485856998370",
+          "id": "postcode",
           "text": "20002"
         },
         {
-          "id": "place.7673410831246050",
+          "id": "place",
           "wikidata": "Q61",
           "text": "Washington"
         },
         {
-          "id": "region.3403",
+          "id": "region.123",
           "short_code": "US-DC",
           "wikidata": "Q61",
           "text": "District of Columbia"
         },
         {
-          "id": "country.3145",
+          "id": "country.123",
           "wikidata": "Q30",
           "short_code": "us",
           "text": "United States"
@@ -110,7 +110,7 @@
       ]
     },
     {
-      "id": "postcode.8356485856998370",
+      "id": "postcode.123",
       "type": "Feature",
       "place_type": [
         "postcode"
@@ -122,36 +122,36 @@
       "text": "20002",
       "place_name": "Washington, District of Columbia 20002, United States",
       "bbox": [
-        -77.0124999956368,
-        38.8875859940734,
-        -76.9438559927196,
-        38.9270120045122
+        -77,
+        38,
+        -76,
+        38
       ],
       "center": [
-        -77.01,
-        38.89
+        -77,
+        38
       ],
       "geometry": {
         "type": "Point",
         "coordinates": [
-          -77.01,
-          38.89
+          -77,
+          38
         ]
       },
       "context": [
         {
-          "id": "place.7673410831246050",
+          "id": "place.123",
           "wikidata": "Q61",
           "text": "Washington"
         },
         {
-          "id": "region.3403",
+          "id": "region.123",
           "short_code": "US-DC",
           "wikidata": "Q61",
           "text": "District of Columbia"
         },
         {
-          "id": "country.3145",
+          "id": "country.123",
           "wikidata": "Q30",
           "short_code": "us",
           "text": "United States"
@@ -159,7 +159,7 @@
       ]
     },
     {
-      "id": "place.7673410831246050",
+      "id": "place.123",
       "type": "Feature",
       "place_type": [
         "place"
@@ -171,31 +171,31 @@
       "text": "Washington",
       "place_name": "Washington, District of Columbia, United States",
       "bbox": [
-        -77.1197609567342,
-        38.79155738,
-        -76.909391,
-        38.99555093
+        -77,
+        38,
+        -76,
+        38
       ],
       "center": [
-        -77.0366,
-        38.895
+        -77,
+        38
       ],
       "geometry": {
         "type": "Point",
         "coordinates": [
-          -77.0366,
-          38.895
+          -77,
+          38
         ]
       },
       "context": [
         {
-          "id": "region.3403",
+          "id": "region.123",
           "short_code": "US-DC",
           "wikidata": "Q61",
           "text": "District of Columbia"
         },
         {
-          "id": "country.3145",
+          "id": "country.123",
           "wikidata": "Q30",
           "short_code": "us",
           "text": "United States"
@@ -203,7 +203,7 @@
       ]
     },
     {
-      "id": "region.3403",
+      "id": "region.123",
       "type": "Feature",
       "place_type": [
         "region"
@@ -216,25 +216,25 @@
       "text": "District of Columbia",
       "place_name": "District of Columbia, United States",
       "bbox": [
-        -77.208138,
-        38.717703,
-        -76.909393,
-        38.995548
+        -77,
+        38,
+        -76,
+        38
       ],
       "center": [
-        -76.990513,
-        38.896391
+        -76,
+        38
       ],
       "geometry": {
         "type": "Point",
         "coordinates": [
-          -76.990513,
-          38.896391
+          -76,
+          38
         ]
       },
       "context": [
         {
-          "id": "country.3145",
+          "id": "country.123",
           "wikidata": "Q30",
           "short_code": "us",
           "text": "United States"
@@ -242,7 +242,7 @@
       ]
     },
     {
-      "id": "country.3145",
+      "id": "country.123",
       "type": "Feature",
       "place_type": [
         "country"
@@ -255,20 +255,20 @@
       "text": "United States",
       "place_name": "United States",
       "bbox": [
-        -179.9,
-        -14.6528,
-        -64.464198,
-        71.540724
+        -179,
+        -14,
+        -64,
+        71
       ],
       "center": [
-        -97.922211,
-        39.381266
+        -97,
+        39
       ],
       "geometry": {
         "type": "Point",
         "coordinates": [
-          -97.922211,
-          39.381266
+          -97,
+          39
         ]
       }
     }


### PR DESCRIPTION
Fixes https://github.com/mapbox/MapboxGeocoder.swift/issues/147.

Improves handling of logic around setting the desired Mapbox Geocoding API endpoint when using MBGeocodeOptions.

cc @kbauhaus 