### PR TITLE
Fix compiler warning

### DIFF
--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -129,7 +129,7 @@ open class Geocoder: NSObject {
      To use this object, a Mapbox [access token](https://www.mapbox.com/help/define-access-token/) should be specified in the `MGLMapboxAccessToken` key in the main application bundle’s Info.plist.
      */
     @objc(sharedGeocoder)
-    open static let shared = Geocoder(accessToken: nil)
+    public static let shared = Geocoder(accessToken: nil)
     
     /// The API endpoint to request the geocodes from.
     internal var apiEndpoint: URL


### PR DESCRIPTION
Static declarations are implicitly final so use `public` access modifier instead of `open`.

/cc @1ec5 