### PR TITLE
Fix non-exhaustive chip check

### DIFF
--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -47,6 +47,10 @@ let userAgent: String = {
         chip = "arm64"
     #elseif arch(i386)
         chip = "i386"
+    #elseif os(watchOS) // Workaround for incorrect arch in machine.h for simulator ⌚️ gen 4
+        chip = "i386"
+    #else
+        chip = "unknown"
     #endif
     components.append("(\(chip))")
     


### PR DESCRIPTION
Fixes #160 Carthage Installation Fails when building for watchOS.

The cross-compiled fat file consists of `i386 armv7k arm64_32`, however, the `if arch(i386)` compilation directive does _not_ catch the i386 architecture when compiling for watchOS simulator despite `sysctlbyname("hw.cputype")` indicating x86 `CPU_TYPE_X86`.

This change works around this by checking for os when it should be checking for arch. I've also made the compilation directive exhaustive by adding an `unknown` chip.

Also, we should get Xcode 10 bots up and running.

@1ec5 @hyerra