### PR TITLE
Fix argument name in documentation

### DIFF
--- a/MapboxGeocoder/MBGeocodeOptions.swift
+++ b/MapboxGeocoder/MBGeocodeOptions.swift
@@ -248,7 +248,7 @@ open class ReverseBatchGeocodeOptions: ReverseGeocodeOptions, BatchGeocodeOption
     /**
      Initializes a reverse batch geocode options object with the given `CLLocation` objects.
      
-     - parameter location: An array of up to 50 `CLLocation` objects to search for.
+     - parameter locations: An array of up to 50 `CLLocation` objects to search for.
      */
     @objc public convenience init(locations: [CLLocation]) {
         self.init(coordinates: locations.map { $0.coordinate })


### PR DESCRIPTION
Corrected an incorrect argument name in a documentation comment that produced the following warning in the navigation SDK:

```
/path/to/mapbox-navigation-ios/Carthage/Build/iOS/MapboxGeocoder.framework/Headers/MapboxGeocoder-Swift.h:473:12: Parameter 'location' not found in the function declaration
/path/to/mapbox-navigation-ios/Example/MBViewController.m:6:9: While building module 'MapboxNavigation' imported from /path/to/mapbox-navigation-ios/Example/MBViewController.m:6:
/Users/mxn/Library/Developer/Xcode/DerivedData/MapboxNavigation-alytgpeiocddhmempehvwkpsbezh/Build/Products/Debug-iphonesimulator/MapboxNavigation.framework/Headers/MapboxNavigation-Swift.h:174:9: While building module 'MapboxGeocoder' imported from /Users/mxn/Library/Developer/Xcode/DerivedData/MapboxNavigation-alytgpeiocddhmempehvwkpsbezh/Build/Products/Debug-iphonesimulator/MapboxNavigation.framework/Headers/MapboxNavigation-Swift.h:174:
/<module-includes>:2:9: In file included from <module-includes>:2:
/path/to/mapbox-navigation-ios/Carthage/Build/iOS/MapboxGeocoder.framework/Headers/MapboxGeocoder-Swift.h:473:12: Did you mean 'locations'?
```

/cc @vincethecoder @frederoni