### PR TITLE
fix missing of errorHandler

### DIFF
--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -268,7 +268,10 @@ open class Geocoder: NSObject {
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         return URLSession.shared.dataTask(with: request) { (data, response, error) in
 
-            guard let data = data else { return }
+            guard let data = data else { 
+                errorHandler(error)
+                return 
+            }
             let decoder = JSONDecoder()
 
             do {


### PR DESCRIPTION
in case that the data task fails, the geocoder still need to call back with errorHandler, otherwise the caller may not complete.