### PR TITLE
Add precision property to Placemark

### DIFF
--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -113,6 +113,14 @@
 		DA737B011E599C2C00AD2CDE /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA737AFC1E599BB300AD2CDE /* OHHTTPStubs.framework */; };
 		DA737B041E599C4A00AD2CDE /* OHHTTPStubs.framework.dSYM in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA737AFF1E599BD400AD2CDE /* OHHTTPStubs.framework.dSYM */; };
 		DA737B051E599C6B00AD2CDE /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA737AFA1E599B9D00AD2CDE /* OHHTTPStubs.framework */; };
+		DA8B5C07225FB2F400CD1C99 /* MBPlacemarkPrecision.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8B5C05225FB2F400CD1C99 /* MBPlacemarkPrecision.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA8B5C08225FB2F400CD1C99 /* MBPlacemarkPrecision.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8B5C05225FB2F400CD1C99 /* MBPlacemarkPrecision.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA8B5C09225FB2F400CD1C99 /* MBPlacemarkPrecision.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8B5C05225FB2F400CD1C99 /* MBPlacemarkPrecision.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA8B5C0A225FB2F400CD1C99 /* MBPlacemarkPrecision.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8B5C05225FB2F400CD1C99 /* MBPlacemarkPrecision.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA8B5C0B225FB2F400CD1C99 /* MBPlacemarkPrecision.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8B5C06225FB2F400CD1C99 /* MBPlacemarkPrecision.m */; };
+		DA8B5C0C225FB2F400CD1C99 /* MBPlacemarkPrecision.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8B5C06225FB2F400CD1C99 /* MBPlacemarkPrecision.m */; };
+		DA8B5C0D225FB2F400CD1C99 /* MBPlacemarkPrecision.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8B5C06225FB2F400CD1C99 /* MBPlacemarkPrecision.m */; };
+		DA8B5C0E225FB2F400CD1C99 /* MBPlacemarkPrecision.m in Sources */ = {isa = PBXBuildFile; fileRef = DA8B5C06225FB2F400CD1C99 /* MBPlacemarkPrecision.m */; };
 		DAA75ED620DDAD760049807C /* MapboxGeocoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDC2470419A1C3B40054B0C0 /* MapboxGeocoder.framework */; };
 		DAA75ED720DDAD760049807C /* MapboxGeocoder.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DDC2470419A1C3B40054B0C0 /* MapboxGeocoder.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DAF158851D03D81600829B35 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DAF158841D03D81600829B35 /* Launch Screen.storyboard */; };
@@ -249,6 +257,8 @@
 		DA737AFA1E599B9D00AD2CDE /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/tvOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		DA737AFC1E599BB300AD2CDE /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/Mac/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		DA737AFF1E599BD400AD2CDE /* OHHTTPStubs.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = OHHTTPStubs.framework.dSYM; path = Carthage/Build/Mac/OHHTTPStubs.framework.dSYM; sourceTree = "<group>"; };
+		DA8B5C05225FB2F400CD1C99 /* MBPlacemarkPrecision.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBPlacemarkPrecision.h; sourceTree = "<group>"; };
+		DA8B5C06225FB2F400CD1C99 /* MBPlacemarkPrecision.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MBPlacemarkPrecision.m; sourceTree = "<group>"; };
 		DAF158841D03D81600829B35 /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		DD342B5019A140EE00219F77 /* Geocoder (Swift).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Geocoder (Swift).app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD342B5419A140EE00219F77 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -415,6 +425,8 @@
 				DA2EC05D1CED732F00D4BA5D /* MBGeocodeOptions.swift */,
 				DDC229591A36073B006BE405 /* MBGeocoder.swift */,
 				DA2E03EF1CB0FDB400D1269A /* MBPlacemark.swift */,
+				DA8B5C05225FB2F400CD1C99 /* MBPlacemarkPrecision.h */,
+				DA8B5C06225FB2F400CD1C99 /* MBPlacemarkPrecision.m */,
 				DA29C8DE1CEBE90200E48A61 /* MBPlacemarkScope.h */,
 				DA2EC05B1CED72E900D4BA5D /* MBPlacemarkScope.swift */,
 				DA2E03F11CB0FE0200D1269A /* MBRectangularRegion.swift */,
@@ -502,6 +514,7 @@
 			files = (
 				DA5170AD1CF1B1DB00CD6DCF /* MapboxGeocoder.h in Headers */,
 				DA5170B11CF1B1E000CD6DCF /* MBPlacemarkScope.h in Headers */,
+				DA8B5C08225FB2F400CD1C99 /* MBPlacemarkPrecision.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -511,6 +524,7 @@
 			files = (
 				DA5170D81CF2541C00CD6DCF /* MapboxGeocoder.h in Headers */,
 				DA5170DC1CF2541C00CD6DCF /* MBPlacemarkScope.h in Headers */,
+				DA8B5C09225FB2F400CD1C99 /* MBPlacemarkPrecision.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -520,6 +534,7 @@
 			files = (
 				DA5170F31CF2582F00CD6DCF /* MapboxGeocoder.h in Headers */,
 				DA5170F71CF2582F00CD6DCF /* MBPlacemarkScope.h in Headers */,
+				DA8B5C0A225FB2F400CD1C99 /* MBPlacemarkPrecision.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -529,6 +544,7 @@
 			files = (
 				DA29C8DF1CEBE90200E48A61 /* MBPlacemarkScope.h in Headers */,
 				DDC2295C1A36074F006BE405 /* MapboxGeocoder.h in Headers */,
+				DA8B5C07225FB2F400CD1C99 /* MBPlacemarkPrecision.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -973,6 +989,7 @@
 				DA5170AF1CF1B1E000CD6DCF /* MBGeocoder.swift in Sources */,
 				DA5170B21CF1B1E000CD6DCF /* MBPlacemarkScope.swift in Sources */,
 				DA5170AE1CF1B1E000CD6DCF /* MBGeocodeOptions.swift in Sources */,
+				DA8B5C0C225FB2F400CD1C99 /* MBPlacemarkPrecision.m in Sources */,
 				35D3DE3A2112410A00B62912 /* CoreLocation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -999,6 +1016,7 @@
 				DA5170DA1CF2541C00CD6DCF /* MBGeocoder.swift in Sources */,
 				DA5170DD1CF2541C00CD6DCF /* MBPlacemarkScope.swift in Sources */,
 				DA5170D91CF2541C00CD6DCF /* MBGeocodeOptions.swift in Sources */,
+				DA8B5C0D225FB2F400CD1C99 /* MBPlacemarkPrecision.m in Sources */,
 				35D3DE3B2112410A00B62912 /* CoreLocation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1025,6 +1043,7 @@
 				DA5170F51CF2582F00CD6DCF /* MBGeocoder.swift in Sources */,
 				DA5170F81CF2582F00CD6DCF /* MBPlacemarkScope.swift in Sources */,
 				DA5170F41CF2582F00CD6DCF /* MBGeocodeOptions.swift in Sources */,
+				DA8B5C0E225FB2F400CD1C99 /* MBPlacemarkPrecision.m in Sources */,
 				35D3DE3C2112410A00B62912 /* CoreLocation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1047,6 +1066,7 @@
 				DDC2295E1A360843006BE405 /* MBGeocoder.swift in Sources */,
 				DA2EC05C1CED72E900D4BA5D /* MBPlacemarkScope.swift in Sources */,
 				DA2E03F01CB0FDB400D1269A /* MBPlacemark.swift in Sources */,
+				DA8B5C0B225FB2F400CD1C99 /* MBPlacemarkPrecision.m in Sources */,
 				35D3DE392112410A00B62912 /* CoreLocation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MapboxGeocoder/MBGeocoder.swift
+++ b/MapboxGeocoder/MBGeocoder.swift
@@ -62,11 +62,9 @@ extension CharacterSet {
      Returns the character set including the characters allowed in the “geocoding query” (file name) part of a Geocoding API URL request.
      */
     internal static func geocodingQueryAllowedCharacterSet() -> CharacterSet {
-        // <rdar://problem/26880260> <https://openradar.appspot.com/26880260>
-        return CharacterSet(charactersIn: "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
-//        var characterSet = CharacterSet.urlPathAllowed
-//        characterSet.remove(charactersIn: "/;")
-//        return characterSet
+        var characterSet = CharacterSet.urlPathAllowed
+        characterSet.remove(charactersIn: "/;")
+        return characterSet
     }
 }
 

--- a/MapboxGeocoder/MBPlacemark.swift
+++ b/MapboxGeocoder/MBPlacemark.swift
@@ -485,6 +485,9 @@ open class GeocodedPlacemark: Placemark {
             } else {
                 return "\(houseNumber) \(streetName)"
             }
+        } else if scope == .address, precision == .intersection {
+            // For intersection features, `text` is just the first street name. The first line of the fully qualified address contains the cross street too.
+            return qualifiedNameComponents.first ?? text
         } else {
             return text
         }

--- a/MapboxGeocoder/MBPlacemark.swift
+++ b/MapboxGeocoder/MBPlacemark.swift
@@ -59,6 +59,8 @@ public let MBPostalAddressCountryKey = "country"
  */
 public let MBPostalAddressISOCountryCodeKey = "ISOCountryCode"
 
+public typealias PlacemarkPrecision = MBPlacemarkPrecision
+
 /**
  A `Placemark` object represents a geocoder result. A placemark associates identifiers, geographic data, and contact information with a particular latitude and longitude. It is possible to explicitly create a placemark object from another placemark object; however, placemark objects are generally created for you via the `Geocoder.geocode(_:completionHandler:)` method.
  */
@@ -376,6 +378,7 @@ internal struct Properties: Codable {
         case phoneNumber = "tel"
         case maki
         case address
+        case precision = "accuracy"
         case category
         case wikidata
     }
@@ -384,6 +387,7 @@ internal struct Properties: Codable {
     let maki: String?
     let phoneNumber: String?
     let address: String?
+    let precision: String?
     let category: String?
     let wikidata: String?
 }
@@ -579,6 +583,18 @@ open class GeocodedPlacemark: Placemark {
      */
     @objc open override var phoneNumber: String? {
         return properties?.phoneNumber
+    }
+    
+    /**
+     The placemark’s precision.
+     
+     The precision offers a general indication of the potential distance between the `location` property and the feature’s actual real-world location.
+     */
+    @objc open var precision: PlacemarkPrecision? {
+        if let precision = properties?.precision {
+            return PlacemarkPrecision(rawValue: precision)
+        }
+        return nil
     }
 }
 

--- a/MapboxGeocoder/MBPlacemarkPrecision.h
+++ b/MapboxGeocoder/MBPlacemarkPrecision.h
@@ -1,0 +1,44 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ An indication of a placemark’s precision.
+ 
+ A placemark’s `MBPlacemarkScope` indicates a feature’s size or importance,
+ whereas its precision indicates how far the reported location may be from the
+ actual real-world location.
+ */
+typedef NSString *MBPlacemarkPrecision NS_TYPED_EXTENSIBLE_ENUM;
+
+/**
+ The placemark represents a specific building with a location on the
+ building’s rooftop or at one of its entrances.
+ */
+extern MBPlacemarkPrecision const MBPlacemarkPrecisionBuilding;
+
+/**
+ The placemark represents a tract or parcel of land with a location at the
+ centroid.
+ */
+extern MBPlacemarkPrecision const MBPlacemarkPrecisionParcel;
+
+/**
+ The placemark represents an address that has been interpolated from an address
+ range. The actual location is generally somewhere along the same block of the
+ same street as the placemark’s location.
+ */
+extern MBPlacemarkPrecision const MBPlacemarkPrecisionInterpolated;
+
+/**
+ The placemark represents a block along a street or an intersection between two
+ or more streets.
+ */
+extern MBPlacemarkPrecision const MBPlacemarkPrecisionIntersection;
+
+/*
+ The placemark represents an entire street with a location at its midpoint.
+ */
+extern MBPlacemarkPrecision const MBPlacemarkPrecisionStreet;
+
+NS_ASSUME_NONNULL_END

--- a/MapboxGeocoder/MBPlacemarkPrecision.m
+++ b/MapboxGeocoder/MBPlacemarkPrecision.m
@@ -1,0 +1,7 @@
+#import "MBPlacemarkPrecision.h"
+
+MBPlacemarkPrecision const MBPlacemarkPrecisionBuilding = @"rooftop";
+MBPlacemarkPrecision const MBPlacemarkPrecisionParcel = @"parcel";
+MBPlacemarkPrecision const MBPlacemarkPrecisionInterpolated = @"interpolated";
+MBPlacemarkPrecision const MBPlacemarkPrecisionIntersection = @"intersection";
+MBPlacemarkPrecision const MBPlacemarkPrecisionStreet = @"street";

--- a/MapboxGeocoder/MapboxGeocoder.h
+++ b/MapboxGeocoder/MapboxGeocoder.h
@@ -8,4 +8,5 @@ FOUNDATION_EXPORT double MapboxGeocoderVersionNumber;
 
 FOUNDATION_EXPORT const unsigned char MapboxGeocoderVersionString[];
 
+#import "MBPlacemarkPrecision.h"
 #import "MBPlacemarkScope.h"


### PR DESCRIPTION
Added the [`Placemark.precision`](https://docs.mapbox.com/api/search/#intersection-search) property to match the Geocoding API. Fixed an issue where the `formattedName` of an intersection placemark contained only one street but not the cross street.

/cc @frederoni @miccolis