### PR TITLE
Update Maps SDK to v5.0.0

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 4.0
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 5.0
 github "frederoni/OHHTTPStubs" "563f48d3fab84ef04639649c770b00f4fa502cca"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "4.10.0"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "5.0.0"
 github "frederoni/OHHTTPStubs" "563f48d3fab84ef04639649c770b00f4fa502cca"


### PR DESCRIPTION
Updates the Maps SDK to v5.0.0, which was [just released this week](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v5.0.0).