### PR TITLE
Use MBXAccessToken as default access token.

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,3 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 5.5
 github "AliSoftware/OHHTTPStubs" ~> 9.0
+github "mapbox/mapbox-events-ios" ~> 0.10.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,3 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "5.9.0"
 github "AliSoftware/OHHTTPStubs" "9.0.0"
+github "mapbox/mapbox-events-ios" "v0.10.8"

--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -931,10 +931,12 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/Mapbox.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/MapboxMobileEvents.framework",
 			);
 			name = "Copy Frameworks";
 			outputPaths = (
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Mapbox.framework",
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/MapboxMobileEvents.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/MapboxGeocoder.xcodeproj/project.pbxproj
+++ b/MapboxGeocoder.xcodeproj/project.pbxproj
@@ -949,6 +949,7 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/Mapbox.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/MapboxMobileEvents.framework",
 			);
 			name = "Copy Frameworks";
 			outputPaths = (

--- a/Sources/MapboxGeocoder/MBGeocoder.swift
+++ b/Sources/MapboxGeocoder/MBGeocoder.swift
@@ -7,7 +7,9 @@ typealias JSONDictionary = [String: Any]
 public let MBGeocoderErrorDomain = "MBGeocoderErrorDomain"
 
 /// The Mapbox access token specified in the main application bundle’s Info.plist.
-let defaultAccessToken = Bundle.main.infoDictionary?["MGLMapboxAccessToken"] as? String
+let defaultAccessToken =
+    Bundle.main.object(forInfoDictionaryKey: "MBXAccessToken") as? String ??
+    Bundle.main.object(forInfoDictionaryKey: "MGLMapboxAccessToken") as? String
 
 /// The user agent string for any HTTP requests performed directly within this library.
 let userAgent: String = {


### PR DESCRIPTION
Use `MBXAccessToken` as default access token. This change is required because CarPlay is using `MapboxGeocoder.swift` for searching.